### PR TITLE
chore: convert 15 plugins to carapace-plugin-sdk

### DIFF
--- a/plugins/fastmail/package.json
+++ b/plugins/fastmail/package.json
@@ -7,11 +7,11 @@
     "fastmail": "./dist/bin/fastmail.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@sinclair/typebox": "^0.34.48"
   },
   "devDependencies": {

--- a/plugins/glances/package.json
+++ b/plugins/glances/package.json
@@ -7,14 +7,14 @@
     "glances": "./dist/bin/glances.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.48"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@types/node": "^25",
     "tsup": "^8.3.0",
     "typescript": "^6",

--- a/plugins/homeassistant/package.json
+++ b/plugins/homeassistant/package.json
@@ -7,12 +7,12 @@
     "homeassistant": "./dist/bin/homeassistant.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.49",
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared"
+    "carapace-plugin-sdk": "^1.0.0"
   },
   "devDependencies": {
     "@types/node": "^25",

--- a/plugins/html-to-pdf/package.json
+++ b/plugins/html-to-pdf/package.json
@@ -7,14 +7,14 @@
     "html-to-pdf": "./dist/bin/html-to-pdf.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.48"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@types/node": "^25",
     "tsup": "^8.3.0",
     "typescript": "^6",

--- a/plugins/ics-calendar/package.json
+++ b/plugins/ics-calendar/package.json
@@ -6,11 +6,11 @@
     "ics-calendar": "./dist/bin/ics-calendar.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "typescript": "^6",
     "@types/node": "^25",
     "tsup": "^8.3.0",

--- a/plugins/llmvision/package.json
+++ b/plugins/llmvision/package.json
@@ -7,12 +7,12 @@
     "llmvision": "./dist/bin/llmvision.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.49",
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared"
+    "carapace-plugin-sdk": "^1.0.0"
   },
   "devDependencies": {
     "typescript": "^6",

--- a/plugins/md-to-html/package.json
+++ b/plugins/md-to-html/package.json
@@ -10,14 +10,14 @@
     "md-to-html": "./dist/bin/md-to-html.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.48"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@types/node": "^25",
     "tsup": "^8.3.0",
     "typescript": "^6",

--- a/plugins/octo-satellite/package.json
+++ b/plugins/octo-satellite/package.json
@@ -7,7 +7,7 @@
     "octo-satellite": "./dist/bin/octo-satellite.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
@@ -16,7 +16,7 @@
     "tsup": "^8.3.0",
     "vitest": "^4.1.5",
     "@sinclair/typebox": "^0.34.0",
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared"
+    "carapace-plugin-sdk": "^1.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/plugins/outlook-calendar/package.json
+++ b/plugins/outlook-calendar/package.json
@@ -7,11 +7,11 @@
     "outlook-calendar": "./dist/bin/outlook-calendar.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "typescript": "^6",
     "@types/node": "^25",
     "tsup": "^8.3.0",

--- a/plugins/outlook-mail/package.json
+++ b/plugins/outlook-mail/package.json
@@ -7,11 +7,11 @@
     "outlook-mail": "./dist/bin/outlook-mail.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "typescript": "^6",
     "@types/node": "^25",
     "tsup": "^8.3.0",

--- a/plugins/outlook-work-calendar/package.json
+++ b/plugins/outlook-work-calendar/package.json
@@ -7,11 +7,11 @@
     "outlook-work-calendar": "./dist/bin/outlook-work-calendar.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "typescript": "^6",
     "@types/node": "^25",
     "tsup": "^8.3.0",

--- a/plugins/spotify/package.json
+++ b/plugins/spotify/package.json
@@ -7,7 +7,7 @@
     "spotify": "./dist/bin/spotify.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
@@ -31,6 +31,6 @@
   },
   "dependencies": {
     "@sinclair/typebox": "^0.34.49",
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared"
+    "carapace-plugin-sdk": "^1.0.0"
   }
 }

--- a/plugins/usps-mail/package.json
+++ b/plugins/usps-mail/package.json
@@ -7,11 +7,11 @@
     "usps-mail": "./dist/bin/usps-mail.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@openclaw/mail-action-usps": "*",
     "@sinclair/typebox": "^0.34.48"
   },

--- a/plugins/weightwatchers/package.json
+++ b/plugins/weightwatchers/package.json
@@ -7,7 +7,7 @@
     "weightwatchers": "./dist/bin/weightwatchers.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "devDependencies": {
@@ -16,7 +16,7 @@
     "tsup": "^8.3.0",
     "vitest": "^4.1.5",
     "@sinclair/typebox": "^0.34.49",
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared"
+    "carapace-plugin-sdk": "^1.0.0"
   },
   "openclaw": {
     "extensions": [

--- a/plugins/withings/package.json
+++ b/plugins/withings/package.json
@@ -7,11 +7,11 @@
     "withings": "./dist/bin/withings.js"
   },
   "scripts": {
-    "build": "tsup && node ../../libs/ts/cli_shared/dist/generate-cli.js --entry ./dist/index.js --out ./dist/bin",
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
     "test": "vitest run"
   },
   "dependencies": {
-    "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
+    "carapace-plugin-sdk": "^1.0.0",
     "@sinclair/typebox": "^0.34.49"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace \@openclaw/cli-shared\ monorepo file: references with \carapace-plugin-sdk ^1.0.0\ from npm across all 15 plugins. Build scripts updated to use \carapace-generate-cli\ instead of the local \generate-cli.js\.

**Plugins converted:** fastmail, glances, homeassistant, html-to-pdf, ics-calendar, llmvision, md-to-html, octo-satellite, outlook-calendar, outlook-mail, outlook-work-calendar, spotify, usps-mail, weightwatchers, withings.

**Not converted:** package-tracking (being extracted to its own carapace repo).

No source code changes — \cli-shared\ was only used as a build tool, and \carapace-generate-cli\ is a drop-in replacement.