### PR TITLE
feat: Obsidian Vault plugin — read-only vault access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "openclaw-hub",
       "version": "2026.4.19",
       "workspaces": [
-        "libs/ts/cli_shared",
-        "libs/ts/package_tracking_core",
-        "libs/ts/mail_runtime_core",
         "libs/ts/mail_action_usps",
         "services/fastmail-sse",
         "plugins/fastmail",
@@ -23,10 +20,10 @@
         "plugins/outlook-calendar",
         "plugins/outlook-mail",
         "plugins/outlook-work-calendar",
-        "plugins/package-tracking",
         "plugins/spotify",
         "plugins/withings",
         "plugins/usps-mail",
+        "plugins/obsidian-vault",
         "plugins/octo-satellite",
         "plugins/weightwatchers"
       ],
@@ -34,9 +31,29 @@
         "tsx": "^4.21.0"
       }
     },
+    "../carapace-plugin-sdk": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "bin": {
+        "carapace-generate-cli": "dist/generate-cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22",
+        "tsup": "^8.3.0",
+        "typescript": "^5.7",
+        "vitest": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "libs/ts/cli_shared": {
       "name": "@openclaw/cli-shared",
       "version": "1.0.0",
+      "extraneous": true,
       "bin": {
         "generate-cli": "dist/generate-cli.js"
       },
@@ -179,10 +196,6 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
-    },
-    "node_modules/@openclaw/cli-shared": {
-      "resolved": "libs/ts/cli_shared",
-      "link": true
     },
     "node_modules/@openclaw/fastmail-sse": {
       "resolved": "services/fastmail-sse",
@@ -539,6 +552,16 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -713,12 +736,96 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "11.10.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.10.0.tgz",
+      "integrity": "sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-require": {
@@ -772,19 +879,8 @@
       }
     },
     "node_modules/carapace-plugin-sdk": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/carapace-plugin-sdk/-/carapace-plugin-sdk-1.0.2.tgz",
-      "integrity": "sha512-1FCCD9WEaI6bQVrpDdG6w65CMDOAA2dz1O4mVRb8ODHp8UoBnfCABJpEyHQvHAC1n6p+W/2oMUnfOtP8i5jifw==",
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "bin": {
-        "carapace-generate-cli": "dist/generate-cli.js"
-      },
-      "engines": {
-        "node": ">=20"
-      }
+      "resolved": "../carapace-plugin-sdk",
+      "link": true
     },
     "node_modules/chai": {
       "version": "5.3.3",
@@ -811,7 +907,6 @@
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "readdirp": "^4.0.1"
@@ -822,6 +917,12 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -867,12 +968,36 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deepmerge": {
@@ -886,7 +1011,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -944,6 +1068,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/entities": {
@@ -1372,6 +1505,19 @@
         "node": ">=12"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "dev": true,
@@ -1380,12 +1526,33 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/fdir": {
@@ -1404,6 +1571,12 @@
         }
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "dev": true,
@@ -1413,6 +1586,12 @@
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1440,9 +1619,30 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glances": {
       "resolved": "plugins/glances",
       "link": true
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -1504,12 +1704,75 @@
       "resolved": "plugins/ics-calendar",
       "link": true
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leac": {
@@ -1894,6 +2157,33 @@
       "resolved": "plugins/md-to-html",
       "link": true
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
+    },
     "node_modules/mlly": {
       "version": "1.8.2",
       "dev": true,
@@ -1942,6 +2232,24 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/nodemailer": {
       "version": "8.0.5",
       "license": "MIT-0",
@@ -1957,6 +2265,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/obsidian-vault": {
+      "resolved": "plugins/obsidian-vault",
+      "link": true
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1967,6 +2279,15 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/outlook-calendar": {
       "resolved": "plugins/outlook-calendar",
@@ -2120,6 +2441,43 @@
         }
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "license": "MIT",
@@ -2127,9 +2485,37 @@
         "node": ">=6"
       }
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14.18.0"
@@ -2232,9 +2618,42 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/selderee": {
       "version": "0.11.0",
@@ -2246,10 +2665,67 @@
         "url": "https://ko-fi.com/killymxi"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/source-map": {
       "version": "0.7.6",
@@ -2271,6 +2747,12 @@
       "resolved": "plugins/spotify",
       "link": true
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "dev": true,
@@ -2280,6 +2762,33 @@
       "version": "3.10.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2300,6 +2809,34 @@
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/thenify": {
@@ -3427,6 +3964,18 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "dev": true,
@@ -3451,6 +4000,12 @@
     "node_modules/undici-types": {
       "version": "7.19.2",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
     "node_modules/vite": {
@@ -3615,12 +4170,18 @@
       "resolved": "plugins/withings",
       "link": true
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "plugins/fastmail": {
       "name": "@openclaw/plugin-fastmail",
       "version": "1.0.0",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
-        "@sinclair/typebox": "^0.34.48"
+        "@sinclair/typebox": "^0.34.48",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "fastmail": "dist/bin/fastmail.js"
@@ -3649,8 +4210,8 @@
         "glances": "dist/bin/glances.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -3668,8 +4229,8 @@
       "name": "homeassistant-cli",
       "version": "1.0.1",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
-        "@sinclair/typebox": "^0.34.49"
+        "@sinclair/typebox": "^0.34.49",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "homeassistant": "dist/bin/homeassistant.js"
@@ -3698,8 +4259,8 @@
         "html-to-pdf": "dist/bin/html-to-pdf.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -3722,8 +4283,8 @@
         "ics-calendar": "dist/bin/ics-calendar.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -3740,8 +4301,8 @@
     "plugins/llmvision": {
       "version": "1.0.1",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
-        "@sinclair/typebox": "^0.34.49"
+        "@sinclair/typebox": "^0.34.49",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "llmvision": "dist/bin/llmvision.js"
@@ -3771,8 +4332,36 @@
         "md-to-html": "dist/bin/md-to-html.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
+        "tsup": "^8.3.0",
+        "typescript": "^6",
+        "vitest": "^2.1.8"
+      },
+      "peerDependencies": {
+        "openclaw": "^2026.4.23"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
+      }
+    },
+    "plugins/obsidian-vault": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.48",
+        "better-sqlite3": "^11.9.1",
+        "chokidar": "^4.0.3",
+        "gray-matter": "^4.0.3"
+      },
+      "bin": {
+        "obsidian-vault": "dist/bin/obsidian-vault.js"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "@types/node": "^25",
+        "carapace-plugin-sdk": "file:/home/openclaw/git/carapace-plugin-sdk",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -3793,9 +4382,9 @@
         "octo-satellite": "dist/bin/octo-satellite.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@sinclair/typebox": "^0.34.0",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^4.1.5"
@@ -4142,8 +4731,8 @@
         "outlook-calendar": "dist/bin/outlook-calendar.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -4166,8 +4755,8 @@
         "outlook-mail": "dist/bin/outlook-mail.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -4190,8 +4779,8 @@
         "outlook-work-calendar": "dist/bin/outlook-work-calendar.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^2.1.8"
@@ -4235,8 +4824,8 @@
     "plugins/spotify": {
       "version": "1.0.1",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
-        "@sinclair/typebox": "^0.34.49"
+        "@sinclair/typebox": "^0.34.49",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "spotify": "dist/bin/spotify.js"
@@ -4285,9 +4874,9 @@
       "name": "@openclaw/plugin-usps-mail",
       "version": "1.0.0",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@openclaw/mail-action-usps": "*",
-        "@sinclair/typebox": "^0.34.48"
+        "@sinclair/typebox": "^0.34.48",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "usps-mail": "dist/bin/usps-mail.js"
@@ -4314,9 +4903,9 @@
         "weightwatchers": "dist/bin/weightwatchers.js"
       },
       "devDependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
         "@sinclair/typebox": "^0.34.49",
         "@types/node": "^25",
+        "carapace-plugin-sdk": "^1.0.0",
         "tsup": "^8.3.0",
         "typescript": "^6",
         "vitest": "^4.1.5"
@@ -4665,8 +5254,8 @@
     "plugins/withings": {
       "version": "1.0.0",
       "dependencies": {
-        "@openclaw/cli-shared": "file:../../libs/ts/cli_shared",
-        "@sinclair/typebox": "^0.34.49"
+        "@sinclair/typebox": "^0.34.49",
+        "carapace-plugin-sdk": "^1.0.0"
       },
       "bin": {
         "withings": "dist/bin/withings.js"

--- a/package.json
+++ b/package.json
@@ -19,12 +19,13 @@
     "plugins/spotify",
     "plugins/withings",
     "plugins/usps-mail",
+    "plugins/obsidian-vault",
     "plugins/octo-satellite",
     "plugins/weightwatchers"
   ],
   "scripts": {
     "build:libs": "npm run build --workspace libs/ts/mail_action_usps && npm run build --workspace services/fastmail-sse",
-    "build:plugins": "npm run build --workspace plugins/fastmail --workspace plugins/glances --workspace plugins/homeassistant --workspace plugins/html-to-pdf --workspace plugins/ics-calendar --workspace plugins/llmvision --workspace plugins/md-to-html --workspace plugins/outlook-calendar --workspace plugins/outlook-mail --workspace plugins/outlook-work-calendar --workspace plugins/spotify --workspace plugins/withings --workspace plugins/usps-mail --workspace plugins/octo-satellite --workspace plugins/weightwatchers",
+    "build:plugins": "npm run build --workspace plugins/fastmail --workspace plugins/glances --workspace plugins/homeassistant --workspace plugins/html-to-pdf --workspace plugins/ics-calendar --workspace plugins/llmvision --workspace plugins/md-to-html --workspace plugins/obsidian-vault --workspace plugins/outlook-calendar --workspace plugins/outlook-mail --workspace plugins/outlook-work-calendar --workspace plugins/spotify --workspace plugins/withings --workspace plugins/usps-mail --workspace plugins/octo-satellite --workspace plugins/weightwatchers",
     "build": "npm run build:libs && npm run build:plugins",
     "test:scripts": "python3 -m unittest scripts.tests.test_export_artifacts",
     "export:artifacts": "python3 scripts/export_artifacts.py",

--- a/plugins/obsidian-vault/openclaw.plugin.json
+++ b/plugins/obsidian-vault/openclaw.plugin.json
@@ -1,0 +1,39 @@
+{
+  "id": "obsidian-vault",
+  "name": "Obsidian Vault",
+  "description": "Read-only access to an Obsidian vault — search, read, and explore notes securely",
+  "version": "1.0.0",
+  "entry": "./dist/adapter.js",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "vaultRoot": {
+        "type": "string",
+        "description": "Absolute path to the Obsidian vault root directory"
+      },
+      "indexLocation": {
+        "type": "string",
+        "description": "Path for the SQLite index database (must be outside vaultRoot)",
+        "default": "~/.openclaw/obsidian-index.db"
+      }
+    },
+    "required": [
+      "vaultRoot"
+    ]
+  },
+  "contracts": {
+    "tools": [
+      "vault_search",
+      "vault_read",
+      "vault_recent",
+      "vault_tags",
+      "vault_backlinks",
+      "vault_related"
+    ]
+  },
+  "activation": {
+    "onStartup": true
+  },
+  "openclaw": {}
+}

--- a/plugins/obsidian-vault/package.json
+++ b/plugins/obsidian-vault/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "obsidian-vault",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "obsidian-vault": "./dist/bin/obsidian-vault.js"
+  },
+  "scripts": {
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48",
+    "better-sqlite3": "^11.9.1",
+    "chokidar": "^4.0.3",
+    "gray-matter": "^4.0.3"
+  },
+  "devDependencies": {
+    "carapace-plugin-sdk": "file:/home/openclaw/git/carapace-plugin-sdk",
+    "@types/better-sqlite3": "^7.6.13",
+    "@types/node": "^25",
+    "tsup": "^8.3.0",
+    "typescript": "^6",
+    "vitest": "^2.1.8"
+  },
+  "peerDependencies": {
+    "openclaw": "^2026.4.23"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/adapter.js"
+    ]
+  }
+}

--- a/plugins/obsidian-vault/src/adapter.ts
+++ b/plugins/obsidian-vault/src/adapter.ts
@@ -1,0 +1,30 @@
+/**
+ * OpenClaw plugin adapter.
+ *
+ * Uses synchronous createRequire (not await import) to avoid top-level await,
+ * which the OpenClaw plugin loader does not support.
+ *
+ * openclaw is an optional peer dependency — falls back to raw entry if not installed.
+ */
+
+import { createRequire } from "node:module";
+import { createEntry } from "./index.js";
+
+const require = createRequire(import.meta.url);
+
+let pluginEntry: unknown;
+
+try {
+  const sdk = require("openclaw/plugin-sdk/plugin-entry") as {
+    definePluginEntry?: (e: unknown) => unknown;
+  };
+  if (typeof sdk.definePluginEntry !== "function") {
+    throw new Error("OpenClaw SDK loaded but did not export `definePluginEntry`. Upgrade the `openclaw` package.");
+  }
+  pluginEntry = sdk.definePluginEntry(createEntry());
+} catch {
+  // Peer dep not installed — fall back to raw entry (works without SDK)
+  pluginEntry = createEntry();
+}
+
+export default pluginEntry;

--- a/plugins/obsidian-vault/src/handlers.ts
+++ b/plugins/obsidian-vault/src/handlers.ts
@@ -1,0 +1,136 @@
+/**
+ * Handlers — core tool logic.
+ *
+ * Pure functions that accept config/index and return structured results.
+ * No knowledge of the plugin framework.
+ */
+
+import { readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { resolveSafePath } from "./security.js";
+import { parseNote } from "./parser.js";
+import type { VaultIndex } from "./indexer.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface VaultConfig {
+  vaultRoot: string;
+  indexLocation: string;
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+export function handleSearch(
+  index: VaultIndex,
+  query: string,
+  limit: number,
+): unknown {
+  if (!index.ready) {
+    return { error: "Index is still being built. Please try again in a moment." };
+  }
+  if (!query.trim()) {
+    return { error: "Query must not be empty" };
+  }
+  try {
+    const results = index.search(query, limit);
+    return { output: results };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { error: `Search failed: ${msg}` };
+  }
+}
+
+export function handleRead(
+  config: VaultConfig,
+  index: VaultIndex,
+  notePath: string,
+): unknown {
+  if (!notePath.trim()) {
+    return { error: "Note path must not be empty" };
+  }
+
+  try {
+    const safePath = resolveSafePath(config.vaultRoot, notePath);
+
+    // Read directly from filesystem for freshest content
+    const raw = readFileSync(safePath, "utf-8");
+    const stat = statSync(safePath);
+    const relPath = relative(config.vaultRoot, safePath);
+    const parsed = parseNote(raw, relPath);
+
+    return {
+      output: {
+        path: relPath,
+        title: parsed.title,
+        content: parsed.content,
+        frontmatter: parsed.frontmatter,
+        tags: parsed.tags,
+        wikilinks: parsed.wikilinks,
+        modified: new Date(stat.mtimeMs).toISOString(),
+      },
+    };
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes("escapes vault root") || msg.includes("Invalid path")) {
+      return { error: `Access denied: ${msg}` };
+    }
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      return { error: `Note not found: ${notePath}` };
+    }
+    return { error: msg };
+  }
+}
+
+export function handleRecent(
+  index: VaultIndex,
+  limit: number,
+): unknown {
+  if (!index.ready) {
+    return { error: "Index is still being built. Please try again in a moment." };
+  }
+  const results = index.listRecent(limit);
+  return {
+    output: results.map((r) => ({
+      path: r.path,
+      title: r.title,
+      modified: new Date(r.mtime_ms).toISOString(),
+    })),
+  };
+}
+
+export function handleTags(index: VaultIndex): unknown {
+  if (!index.ready) {
+    return { error: "Index is still being built. Please try again in a moment." };
+  }
+  return { output: index.listTags() };
+}
+
+export function handleBacklinks(
+  index: VaultIndex,
+  notePath: string,
+): unknown {
+  if (!index.ready) {
+    return { error: "Index is still being built. Please try again in a moment." };
+  }
+  if (!notePath.trim()) {
+    return { error: "Note path must not be empty" };
+  }
+  return { output: index.getBacklinks(notePath) };
+}
+
+export function handleRelated(
+  index: VaultIndex,
+  notePath: string,
+): unknown {
+  if (!index.ready) {
+    return { error: "Index is still being built. Please try again in a moment." };
+  }
+  if (!notePath.trim()) {
+    return { error: "Note path must not be empty" };
+  }
+  return { output: index.getRelatedNotes(notePath) };
+}

--- a/plugins/obsidian-vault/src/index.ts
+++ b/plugins/obsidian-vault/src/index.ts
@@ -1,0 +1,242 @@
+/**
+ * Obsidian Vault plugin — OpenClaw plugin shim.
+ *
+ * Constructs config from pluginConfig, registers tools that delegate to handlers.
+ */
+
+import { Type } from "@sinclair/typebox";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { canonicalizeVaultRoot, validateIndexLocation } from "./security.js";
+import { VaultIndex } from "./indexer.js";
+import {
+  handleSearch,
+  handleRead,
+  handleRecent,
+  handleTags,
+  handleBacklinks,
+  handleRelated,
+  type VaultConfig,
+} from "./handlers.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PluginApi = {
+  registerTool: (tool: unknown) => void;
+  pluginConfig?: Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatResult(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: typeof data === "string" ? data : JSON.stringify(data) }],
+    details: {},
+  };
+}
+
+function expandHome(p: string): string {
+  if (p.startsWith("~/") || p === "~") {
+    return resolve(homedir(), p.slice(2));
+  }
+  return p;
+}
+
+function buildConfig(pluginConfig?: Record<string, unknown>): VaultConfig {
+  const vaultRoot = ((pluginConfig?.vaultRoot as string) ?? "").trim();
+  if (!vaultRoot) {
+    throw new Error("obsidian-vault plugin requires 'vaultRoot' configuration");
+  }
+
+  const rawIndex = ((pluginConfig?.indexLocation as string) ?? "").trim()
+    || "~/.openclaw/obsidian-index.db";
+
+  const canonicalRoot = canonicalizeVaultRoot(expandHome(vaultRoot));
+  const indexLocation = resolve(expandHome(rawIndex));
+
+  validateIndexLocation(canonicalRoot, indexLocation);
+
+  return { vaultRoot: canonicalRoot, indexLocation };
+}
+
+// ---------------------------------------------------------------------------
+// Config schema
+// ---------------------------------------------------------------------------
+
+const configSchema = {
+  type: "object" as const,
+  additionalProperties: false,
+  properties: {
+    vaultRoot: {
+      type: "string" as const,
+      description: "Absolute path to the Obsidian vault root directory",
+    },
+    indexLocation: {
+      type: "string" as const,
+      description: "Path for the SQLite index database (must be outside vaultRoot)",
+      default: "~/.openclaw/obsidian-index.db",
+    },
+  },
+  required: ["vaultRoot"],
+};
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+function createEntry() {
+  return {
+    id: "obsidian-vault",
+    name: "Obsidian Vault",
+    description: "Read-only access to an Obsidian vault — search, read, and explore notes securely",
+    contracts: {
+      tools: [
+        "vault_search",
+        "vault_read",
+        "vault_recent",
+        "vault_tags",
+        "vault_backlinks",
+        "vault_related",
+      ],
+    },
+    configSchema,
+    register(api: PluginApi) {
+      const config = buildConfig(api.pluginConfig);
+      const index = new VaultIndex(config);
+
+      // Start indexing in background — don't block plugin registration
+      index.startIndexing().catch((err) => {
+        console.error("[obsidian-vault] Indexing failed:", err);
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_search
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_search",
+        label: "Vault Search",
+        description:
+          "Full-text search across all notes in the Obsidian vault. Returns ranked results with snippets.",
+        parameters: Type.Object({
+          query: Type.String({
+            description: "Search query string (FTS5 syntax supported)",
+          }),
+          limit: Type.Optional(
+            Type.Number({
+              description: "Maximum number of results (default: 20)",
+              default: 20,
+              minimum: 1,
+              maximum: 100,
+            }),
+          ),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const query = ((params.query as string) ?? "").trim();
+          const limit = Math.min(Math.max(Number(params.limit) || 20, 1), 100);
+          return formatResult(handleSearch(index, query, limit));
+        },
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_read
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_read",
+        label: "Vault Read",
+        description:
+          "Read a single note from the Obsidian vault. Returns parsed content, frontmatter, tags, and wikilinks.",
+        parameters: Type.Object({
+          path: Type.String({
+            description:
+              "Relative path to the note within the vault (e.g. 'Projects/Home Assistant/Battery Monitoring.md')",
+          }),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const notePath = ((params.path as string) ?? "").trim();
+          return formatResult(handleRead(config, index, notePath));
+        },
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_recent
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_recent",
+        label: "Vault Recent Notes",
+        description: "List recently modified notes, sorted by modification time.",
+        parameters: Type.Object({
+          limit: Type.Optional(
+            Type.Number({
+              description: "Maximum number of results (default: 20)",
+              default: 20,
+              minimum: 1,
+              maximum: 100,
+            }),
+          ),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const limit = Math.min(Math.max(Number(params.limit) || 20, 1), 100);
+          return formatResult(handleRecent(index, limit));
+        },
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_tags
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_tags",
+        label: "Vault Tags",
+        description: "List all tags used across the Obsidian vault.",
+        parameters: Type.Object({}),
+        async execute(_toolCallId: string, _params: Record<string, unknown>) {
+          return formatResult(handleTags(index));
+        },
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_backlinks
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_backlinks",
+        label: "Vault Backlinks",
+        description:
+          "Find notes that link to a given note using [[wikilinks]].",
+        parameters: Type.Object({
+          path: Type.String({
+            description: "Path of the target note to find backlinks for",
+          }),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const notePath = ((params.path as string) ?? "").trim();
+          return formatResult(handleBacklinks(index, notePath));
+        },
+      });
+
+      // -----------------------------------------------------------------------
+      // vault_related
+      // -----------------------------------------------------------------------
+      api.registerTool({
+        name: "vault_related",
+        label: "Vault Related Notes",
+        description:
+          "Find notes related to a given note via wikilinks and shared tags. " +
+          "Returns results sorted by relevance with relationship reasons.",
+        parameters: Type.Object({
+          path: Type.String({
+            description: "Path of the note to find related notes for",
+          }),
+        }),
+        async execute(_toolCallId: string, params: Record<string, unknown>) {
+          const notePath = ((params.path as string) ?? "").trim();
+          return formatResult(handleRelated(index, notePath));
+        },
+      });
+    },
+  };
+}
+
+export { createEntry };

--- a/plugins/obsidian-vault/src/indexer.ts
+++ b/plugins/obsidian-vault/src/indexer.ts
@@ -1,0 +1,462 @@
+/**
+ * Indexer — SQLite FTS5 index for Obsidian vault notes.
+ *
+ * Provides full-text search, tag indexing, and link graph storage.
+ * Uses better-sqlite3 for synchronous SQLite access.
+ * File watching via chokidar for incremental updates.
+ */
+
+import { readFileSync, statSync, mkdirSync } from "node:fs";
+import { join, relative, dirname, extname, basename } from "node:path";
+import Database from "better-sqlite3";
+import type BetterSqlite3 from "better-sqlite3";
+import { watch } from "chokidar";
+import type { FSWatcher } from "chokidar";
+import { parseNote } from "./parser.js";
+import { resolveSafePath } from "./security.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface IndexConfig {
+  vaultRoot: string;
+  indexLocation: string;
+}
+
+export interface SearchResult {
+  path: string;
+  title: string;
+  snippet: string;
+  rank: number;
+}
+
+export interface NoteRecord {
+  path: string;
+  title: string;
+  content: string;
+  frontmatter_json: string;
+  mtime_ms: number;
+}
+
+export interface RecentNote {
+  path: string;
+  title: string;
+  mtime_ms: number;
+}
+
+// ---------------------------------------------------------------------------
+// Index class
+// ---------------------------------------------------------------------------
+
+export class VaultIndex {
+  private db: BetterSqlite3.Database;
+  private vaultRoot: string;
+  private watcher: FSWatcher | null = null;
+  private _ready = false;
+  private _indexingPromise: Promise<void> | null = null;
+
+  constructor(config: IndexConfig) {
+    this.vaultRoot = config.vaultRoot;
+
+    // Ensure index directory exists
+    mkdirSync(dirname(config.indexLocation), { recursive: true });
+
+    this.db = new Database(config.indexLocation);
+    this.db.pragma("journal_mode = WAL");
+    this.db.pragma("foreign_keys = ON");
+    this.initSchema();
+  }
+
+  get ready(): boolean {
+    return this._ready;
+  }
+
+  // -------------------------------------------------------------------------
+  // Schema
+  // -------------------------------------------------------------------------
+
+  private initSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS notes (
+        path TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        content TEXT NOT NULL,
+        frontmatter_json TEXT NOT NULL DEFAULT '{}',
+        mtime_ms INTEGER NOT NULL
+      );
+
+      CREATE VIRTUAL TABLE IF NOT EXISTS notes_fts USING fts5(
+        title,
+        content,
+        content='notes',
+        content_rowid='rowid'
+      );
+
+      -- Triggers to keep FTS in sync
+      CREATE TRIGGER IF NOT EXISTS notes_ai AFTER INSERT ON notes BEGIN
+        INSERT INTO notes_fts(rowid, title, content)
+        VALUES (new.rowid, new.title, new.content);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS notes_ad AFTER DELETE ON notes BEGIN
+        INSERT INTO notes_fts(notes_fts, rowid, title, content)
+        VALUES ('delete', old.rowid, old.title, old.content);
+      END;
+
+      CREATE TRIGGER IF NOT EXISTS notes_au AFTER UPDATE ON notes BEGIN
+        INSERT INTO notes_fts(notes_fts, rowid, title, content)
+        VALUES ('delete', old.rowid, old.title, old.content);
+        INSERT INTO notes_fts(rowid, title, content)
+        VALUES (new.rowid, new.title, new.content);
+      END;
+
+      CREATE TABLE IF NOT EXISTS tags (
+        note_path TEXT NOT NULL,
+        tag TEXT NOT NULL,
+        PRIMARY KEY (note_path, tag),
+        FOREIGN KEY (note_path) REFERENCES notes(path) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_tags_tag ON tags(tag);
+
+      CREATE TABLE IF NOT EXISTS links (
+        source_path TEXT NOT NULL,
+        target TEXT NOT NULL,
+        alias TEXT,
+        FOREIGN KEY (source_path) REFERENCES notes(path) ON DELETE CASCADE
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_links_source ON links(source_path);
+      CREATE INDEX IF NOT EXISTS idx_links_target ON links(target);
+    `);
+  }
+
+  // -------------------------------------------------------------------------
+  // Indexing
+  // -------------------------------------------------------------------------
+
+  /**
+   * Start the initial full vault scan and file watcher.
+   * Returns a promise that resolves when initial indexing is complete.
+   */
+  async startIndexing(): Promise<void> {
+    if (this._indexingPromise) return this._indexingPromise;
+
+    this._indexingPromise = this.performFullScan().then(() => {
+      this._ready = true;
+      this.startWatcher();
+    });
+
+    return this._indexingPromise;
+  }
+
+  private async performFullScan(): Promise<void> {
+    const { readdirSync } = await import("node:fs");
+    const files = this.collectMarkdownFiles(this.vaultRoot, readdirSync);
+
+    // Batch insert for performance
+    const insertNote = this.db.prepare(`
+      INSERT OR REPLACE INTO notes (path, title, content, frontmatter_json, mtime_ms)
+      VALUES (@path, @title, @content, @frontmatter_json, @mtime_ms)
+    `);
+    const insertTag = this.db.prepare(
+      `INSERT OR REPLACE INTO tags (note_path, tag) VALUES (@note_path, @tag)`
+    );
+    const insertLink = this.db.prepare(
+      `INSERT INTO links (source_path, target, alias) VALUES (@source_path, @target, @alias)`
+    );
+    const deleteLinks = this.db.prepare(`DELETE FROM links WHERE source_path = ?`);
+    const deleteTags = this.db.prepare(`DELETE FROM tags WHERE note_path = ?`);
+
+    const batchSize = 100;
+    for (let i = 0; i < files.length; i += batchSize) {
+      const batch = files.slice(i, i + batchSize);
+      const txn = this.db.transaction(() => {
+        for (const filePath of batch) {
+          this.indexSingleFile(filePath, insertNote, insertTag, insertLink, deleteLinks, deleteTags);
+        }
+      });
+      txn();
+
+      // Yield to event loop between batches
+      if (i + batchSize < files.length) {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+    }
+  }
+
+  private collectMarkdownFiles(
+    dir: string,
+    readdirSync: (p: string, opts: { withFileTypes: true }) => import("node:fs").Dirent[],
+  ): string[] {
+    const files: string[] = [];
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        // Skip hidden files/dirs (starting with .)
+        if (entry.name.startsWith(".")) continue;
+
+        const fullPath = join(dir, entry.name);
+
+        if (entry.isDirectory()) {
+          files.push(...this.collectMarkdownFiles(fullPath, readdirSync));
+        } else if (entry.isFile() && extname(entry.name).toLowerCase() === ".md") {
+          files.push(fullPath);
+        }
+        // Skip symlinks entirely
+      }
+    } catch {
+      // Skip directories we can't read
+    }
+    return files;
+  }
+
+  private indexSingleFile(
+    absolutePath: string,
+    insertNote: BetterSqlite3.Statement,
+    insertTag: BetterSqlite3.Statement,
+    insertLink: BetterSqlite3.Statement,
+    deleteLinks: BetterSqlite3.Statement,
+    deleteTags: BetterSqlite3.Statement,
+  ): void {
+    try {
+      const relPath = relative(this.vaultRoot, absolutePath);
+      const raw = readFileSync(absolutePath, "utf-8");
+      const stat = statSync(absolutePath);
+      const parsed = parseNote(raw, relPath);
+
+      insertNote.run({
+        path: relPath,
+        title: parsed.title,
+        content: parsed.content,
+        frontmatter_json: JSON.stringify(parsed.frontmatter),
+        mtime_ms: stat.mtimeMs,
+      });
+
+      // Clear old tags/links and re-insert
+      deleteTags.run(relPath);
+      deleteLinks.run(relPath);
+
+      for (const tag of parsed.tags) {
+        insertTag.run({ note_path: relPath, tag });
+      }
+
+      for (const link of parsed.wikilinks) {
+        insertLink.run({
+          source_path: relPath,
+          target: link.target,
+          alias: link.alias,
+        });
+      }
+    } catch {
+      // Skip files that can't be read or parsed
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // File watcher
+  // -------------------------------------------------------------------------
+
+  private startWatcher(): void {
+    this.watcher = watch(this.vaultRoot, {
+      ignored: /(^|[/\\])\./,  // Ignore dotfiles
+      persistent: true,
+      followSymlinks: false,
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 300, pollInterval: 100 },
+    });
+
+    const stmts = this.prepareStatements();
+
+    this.watcher
+      .on("add", (path) => this.onFileChange(path, stmts))
+      .on("change", (path) => this.onFileChange(path, stmts))
+      .on("unlink", (path) => this.onFileRemove(path));
+  }
+
+  private prepareStatements() {
+    return {
+      insertNote: this.db.prepare(`
+        INSERT OR REPLACE INTO notes (path, title, content, frontmatter_json, mtime_ms)
+        VALUES (@path, @title, @content, @frontmatter_json, @mtime_ms)
+      `),
+      insertTag: this.db.prepare(
+        `INSERT OR REPLACE INTO tags (note_path, tag) VALUES (@note_path, @tag)`
+      ),
+      insertLink: this.db.prepare(
+        `INSERT INTO links (source_path, target, alias) VALUES (@source_path, @target, @alias)`
+      ),
+      deleteLinks: this.db.prepare(`DELETE FROM links WHERE source_path = ?`),
+      deleteTags: this.db.prepare(`DELETE FROM tags WHERE note_path = ?`),
+    };
+  }
+
+  private onFileChange(
+    absolutePath: string,
+    stmts: ReturnType<typeof this.prepareStatements>,
+  ): void {
+    if (extname(absolutePath).toLowerCase() !== ".md") return;
+    try {
+      this.indexSingleFile(
+        absolutePath,
+        stmts.insertNote,
+        stmts.insertTag,
+        stmts.insertLink,
+        stmts.deleteLinks,
+        stmts.deleteTags,
+      );
+    } catch {
+      // Ignore indexing errors for individual files
+    }
+  }
+
+  private onFileRemove(absolutePath: string): void {
+    if (extname(absolutePath).toLowerCase() !== ".md") return;
+    try {
+      const relPath = relative(this.vaultRoot, absolutePath);
+      this.db.prepare(`DELETE FROM notes WHERE path = ?`).run(relPath);
+    } catch {
+      // Ignore
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Query methods
+  // -------------------------------------------------------------------------
+
+  search(query: string, limit: number = 20): SearchResult[] {
+    const stmt = this.db.prepare(`
+      SELECT
+        n.path,
+        n.title,
+        snippet(notes_fts, 1, '>>>', '<<<', '...', 40) AS snippet,
+        rank
+      FROM notes_fts
+      JOIN notes n ON n.rowid = notes_fts.rowid
+      WHERE notes_fts MATCH @query
+      ORDER BY rank
+      LIMIT @limit
+    `);
+
+    return stmt.all({ query, limit }) as SearchResult[];
+  }
+
+  readNote(relPath: string): NoteRecord | null {
+    const stmt = this.db.prepare(`SELECT * FROM notes WHERE path = ?`);
+    return (stmt.get(relPath) as NoteRecord) ?? null;
+  }
+
+  listRecent(limit: number = 20): RecentNote[] {
+    const stmt = this.db.prepare(`
+      SELECT path, title, mtime_ms
+      FROM notes
+      ORDER BY mtime_ms DESC
+      LIMIT ?
+    `);
+    return stmt.all(limit) as RecentNote[];
+  }
+
+  listTags(): string[] {
+    const rows = this.db.prepare(`SELECT DISTINCT tag FROM tags ORDER BY tag`).all() as { tag: string }[];
+    return rows.map((r) => r.tag);
+  }
+
+  getBacklinks(notePath: string): { path: string; title: string }[] {
+    // Resolve the target: match by exact path, by basename, or without .md extension
+    const noteBasename = basename(notePath, ".md");
+
+    const stmt = this.db.prepare(`
+      SELECT DISTINCT n.path, n.title
+      FROM links l
+      JOIN notes n ON n.path = l.source_path
+      WHERE l.target = @exact
+         OR l.target = @basename
+         OR l.target = @withExt
+      ORDER BY n.title
+    `);
+
+    return stmt.all({
+      exact: notePath,
+      basename: noteBasename,
+      withExt: notePath.endsWith(".md") ? notePath : notePath + ".md",
+    }) as { path: string; title: string }[];
+  }
+
+  getRelatedNotes(notePath: string): { path: string; title: string; reasons: string[] }[] {
+    // Find related notes via shared links and shared tags
+    const relatedMap = new Map<string, { title: string; reasons: Set<string> }>();
+
+    // 1. Notes linked from this note
+    const outgoing = this.db.prepare(`
+      SELECT DISTINCT n.path, n.title, l.target
+      FROM links l
+      JOIN notes n ON (
+        n.path = l.target
+        OR n.path = l.target || '.md'
+        OR n.path LIKE '%/' || l.target || '.md'
+      )
+      WHERE l.source_path = ?
+    `).all(notePath) as { path: string; title: string; target: string }[];
+
+    for (const row of outgoing) {
+      if (row.path === notePath) continue;
+      const entry = relatedMap.get(row.path) ?? { title: row.title, reasons: new Set() };
+      entry.reasons.add("linked-from-this-note");
+      relatedMap.set(row.path, entry);
+    }
+
+    // 2. Notes that link to this note (backlinks)
+    const backlinks = this.getBacklinks(notePath);
+    for (const bl of backlinks) {
+      if (bl.path === notePath) continue;
+      const entry = relatedMap.get(bl.path) ?? { title: bl.title, reasons: new Set() };
+      entry.reasons.add("links-to-this-note");
+      relatedMap.set(bl.path, entry);
+    }
+
+    // 3. Notes sharing tags
+    const noteTags = this.db.prepare(
+      `SELECT tag FROM tags WHERE note_path = ?`
+    ).all(notePath) as { tag: string }[];
+
+    if (noteTags.length > 0) {
+      const tagValues = noteTags.map((t) => t.tag);
+      const placeholders = tagValues.map(() => "?").join(",");
+      const sharedTagNotes = this.db.prepare(`
+        SELECT DISTINCT n.path, n.title, t.tag
+        FROM tags t
+        JOIN notes n ON n.path = t.note_path
+        WHERE t.tag IN (${placeholders})
+          AND t.note_path != ?
+      `).all(...tagValues, notePath) as { path: string; title: string; tag: string }[];
+
+      for (const row of sharedTagNotes) {
+        const entry = relatedMap.get(row.path) ?? { title: row.title, reasons: new Set() };
+        entry.reasons.add(`shared-tag:${row.tag}`);
+        relatedMap.set(row.path, entry);
+      }
+    }
+
+    return [...relatedMap.entries()]
+      .map(([path, { title, reasons }]) => ({ path, title, reasons: [...reasons] }))
+      .sort((a, b) => b.reasons.length - a.reasons.length);
+  }
+
+  getNoteCount(): number {
+    const row = this.db.prepare(`SELECT COUNT(*) as count FROM notes`).get() as { count: number };
+    return row.count;
+  }
+
+  // -------------------------------------------------------------------------
+  // Cleanup
+  // -------------------------------------------------------------------------
+
+  async close(): Promise<void> {
+    if (this.watcher) {
+      await this.watcher.close();
+      this.watcher = null;
+    }
+    this.db.close();
+  }
+}

--- a/plugins/obsidian-vault/src/parser.ts
+++ b/plugins/obsidian-vault/src/parser.ts
@@ -1,0 +1,164 @@
+/**
+ * Parser — Markdown frontmatter, wikilink, and tag extraction.
+ *
+ * Handles Obsidian-flavored Markdown features without requiring Obsidian.
+ */
+
+import matter from "gray-matter";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ParsedNote {
+  title: string;
+  content: string;
+  frontmatter: Record<string, unknown>;
+  tags: string[];
+  wikilinks: WikiLink[];
+}
+
+export interface WikiLink {
+  target: string;
+  alias: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Frontmatter
+// ---------------------------------------------------------------------------
+
+export function parseFrontmatter(raw: string): { content: string; frontmatter: Record<string, unknown> } {
+  try {
+    const result = matter(raw);
+    return {
+      content: result.content,
+      frontmatter: (result.data as Record<string, unknown>) ?? {},
+    };
+  } catch {
+    // If frontmatter parsing fails, treat entire content as body
+    return { content: raw, frontmatter: {} };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tag extraction
+// ---------------------------------------------------------------------------
+
+const FENCED_CODE_BLOCK = /^```[\s\S]*?^```/gm;
+const INLINE_CODE = /`[^`]+`/g;
+
+/** Match inline tags: #word but not inside code */
+const TAG_PATTERN = /(?:^|\s)#([a-zA-Z][\w-/]*)/g;
+
+/**
+ * Extract all tags from a note. Combines:
+ * - YAML frontmatter `tags` / `tag` fields
+ * - Inline `#tag` occurrences (outside code blocks)
+ */
+export function extractTags(content: string, frontmatter: Record<string, unknown>): string[] {
+  const tags = new Set<string>();
+
+  // Frontmatter tags
+  for (const key of ["tags", "tag"]) {
+    const val = frontmatter[key];
+    if (Array.isArray(val)) {
+      for (const t of val) {
+        if (typeof t === "string" && t.trim()) {
+          tags.add(normalizeTag(t.trim()));
+        }
+      }
+    } else if (typeof val === "string" && val.trim()) {
+      // Comma or space separated
+      for (const t of val.split(/[,\s]+/)) {
+        if (t.trim()) tags.add(normalizeTag(t.trim()));
+      }
+    }
+  }
+
+  // Inline tags — strip code blocks first
+  const stripped = content.replace(FENCED_CODE_BLOCK, "").replace(INLINE_CODE, "");
+  let match: RegExpExecArray | null;
+  while ((match = TAG_PATTERN.exec(stripped)) !== null) {
+    tags.add(normalizeTag(match[1]));
+  }
+
+  return [...tags].sort();
+}
+
+function normalizeTag(tag: string): string {
+  // Remove leading # if present
+  return tag.startsWith("#") ? tag.slice(1).toLowerCase() : tag.toLowerCase();
+}
+
+// ---------------------------------------------------------------------------
+// Wikilink extraction
+// ---------------------------------------------------------------------------
+
+const WIKILINK_PATTERN = /\[\[([^\]|#]+)(?:#[^\]|]*)?(?:\|([^\]]+))?\]\]/g;
+
+/**
+ * Extract all wikilinks from Markdown content.
+ * Handles: [[Note]], [[Note|alias]], [[Note#heading]], [[Note#heading|alias]]
+ */
+export function extractWikilinks(content: string): WikiLink[] {
+  const links: WikiLink[] = [];
+  const seen = new Set<string>();
+  let match: RegExpExecArray | null;
+
+  // Strip code blocks
+  const stripped = content.replace(FENCED_CODE_BLOCK, "").replace(INLINE_CODE, "");
+
+  while ((match = WIKILINK_PATTERN.exec(stripped)) !== null) {
+    const target = match[1].trim();
+    const alias = match[2]?.trim() ?? null;
+    const key = `${target}|${alias ?? ""}`;
+    if (target && !seen.has(key)) {
+      seen.add(key);
+      links.push({ target, alias });
+    }
+  }
+
+  return links;
+}
+
+// ---------------------------------------------------------------------------
+// Full note parsing
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive a title from the note. Priority:
+ * 1. Frontmatter `title` field
+ * 2. First H1 (`# Title`)
+ * 3. Filename without extension
+ */
+export function deriveTitle(
+  frontmatter: Record<string, unknown>,
+  content: string,
+  filePath: string,
+): string {
+  if (typeof frontmatter.title === "string" && frontmatter.title.trim()) {
+    return frontmatter.title.trim();
+  }
+
+  const h1Match = content.match(/^#\s+(.+)$/m);
+  if (h1Match) {
+    return h1Match[1].trim();
+  }
+
+  // Filename without extension
+  const parts = filePath.replace(/\\/g, "/").split("/");
+  const filename = parts[parts.length - 1] ?? filePath;
+  return filename.replace(/\.md$/i, "");
+}
+
+/**
+ * Parse a raw Markdown file into structured note data.
+ */
+export function parseNote(raw: string, filePath: string): ParsedNote {
+  const { content, frontmatter } = parseFrontmatter(raw);
+  const title = deriveTitle(frontmatter, content, filePath);
+  const tags = extractTags(content, frontmatter);
+  const wikilinks = extractWikilinks(content);
+
+  return { title, content, frontmatter, tags, wikilinks };
+}

--- a/plugins/obsidian-vault/src/security.ts
+++ b/plugins/obsidian-vault/src/security.ts
@@ -1,0 +1,90 @@
+/**
+ * Security — path validation and traversal prevention.
+ *
+ * All file access must go through resolveSafePath to ensure confinement
+ * to the configured vault root directory.
+ */
+
+import { resolve, relative, sep } from "node:path";
+import { realpathSync, lstatSync } from "node:fs";
+
+/**
+ * Resolve a user-supplied path relative to the vault root, ensuring it stays
+ * within the vault boundary. Rejects path traversal and symlink escapes.
+ *
+ * @param vaultRoot Canonical (realpath-resolved) vault root directory
+ * @param requestedPath Relative note path (e.g. "Projects/Home Assistant/Battery.md")
+ * @returns Canonical absolute path guaranteed to be inside vaultRoot
+ * @throws Error if path escapes vault or targets a symlink outside vault
+ */
+export function resolveSafePath(vaultRoot: string, requestedPath: string): string {
+  if (!requestedPath) {
+    throw new Error("Path must not be empty");
+  }
+
+  // Reject obviously malicious patterns before doing any filesystem work
+  const normalized = requestedPath.replace(/\\/g, "/");
+  if (normalized.startsWith("/") || normalized.includes("\0")) {
+    throw new Error("Invalid path: absolute paths and null bytes are not allowed");
+  }
+
+  // Join and canonicalize
+  const joined = resolve(vaultRoot, requestedPath);
+
+  let canonical: string;
+  try {
+    canonical = realpathSync(joined);
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      // File doesn't exist yet — check the joined path directly
+      // Verify the non-symlink-resolved path is still inside vault
+      const rel = relative(vaultRoot, joined);
+      if (rel.startsWith("..") || rel.startsWith(sep + sep)) {
+        throw new Error("Path escapes vault root");
+      }
+      return joined;
+    }
+    throw e;
+  }
+
+  // Ensure canonical path is within the canonical vault root
+  if (!canonical.startsWith(vaultRoot + sep) && canonical !== vaultRoot) {
+    throw new Error("Path escapes vault root");
+  }
+
+  return canonical;
+}
+
+/**
+ * Canonicalize the vault root directory, ensuring it exists and is a directory.
+ */
+export function canonicalizeVaultRoot(vaultRoot: string): string {
+  try {
+    const canonical = realpathSync(vaultRoot);
+    const stat = lstatSync(canonical);
+    if (!stat.isDirectory()) {
+      throw new Error(`Vault root is not a directory: ${vaultRoot}`);
+    }
+    return canonical;
+  } catch (e: unknown) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new Error(`Vault root does not exist: ${vaultRoot}`);
+    }
+    throw e;
+  }
+}
+
+/**
+ * Validate that the index location is not inside the vault root.
+ */
+export function validateIndexLocation(vaultRoot: string, indexLocation: string): void {
+  const canonicalIndex = resolve(indexLocation);
+  if (canonicalIndex.startsWith(vaultRoot + sep) || canonicalIndex === vaultRoot) {
+    throw new Error(
+      `Index location must not be inside vault root. ` +
+      `vaultRoot=${vaultRoot}, indexLocation=${indexLocation}`
+    );
+  }
+}

--- a/plugins/obsidian-vault/tests/handlers.test.ts
+++ b/plugins/obsidian-vault/tests/handlers.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for the Obsidian Vault plugin.
+ *
+ * Uses a temporary directory with real files to test the full pipeline:
+ * parsing, indexing, security, and tool handlers.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// ---------------------------------------------------------------------------
+// Test vault setup
+// ---------------------------------------------------------------------------
+
+const TEST_ROOT = join(tmpdir(), `obsidian-vault-test-${Date.now()}`);
+const VAULT_ROOT = join(TEST_ROOT, "vault");
+const INDEX_PATH = join(TEST_ROOT, "index.db");
+
+function writeNote(relPath: string, content: string): void {
+  const abs = join(VAULT_ROOT, relPath);
+  const dir = abs.substring(0, abs.lastIndexOf("/"));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(abs, content, "utf-8");
+}
+
+beforeAll(() => {
+  mkdirSync(VAULT_ROOT, { recursive: true });
+
+  writeNote("Projects/Battery Monitoring.md", `---
+title: Battery Monitoring
+tags: [homeassistant, automation]
+---
+
+# Battery Monitoring
+
+Monitor battery levels for all devices. See also [[Zigbee Devices]] and [[Home Dashboard|Dashboard]].
+
+#monitoring #iot
+`);
+
+  writeNote("Projects/Zigbee Devices.md", `---
+tags: homeassistant
+---
+
+# Zigbee Devices
+
+List of Zigbee devices on the network. Related to [[Battery Monitoring]].
+
+#networking #iot
+`);
+
+  writeNote("Projects/Home Dashboard.md", `---
+title: Home Dashboard
+---
+
+# Home Dashboard
+
+Central dashboard for Home Assistant. Links to [[Battery Monitoring]] and [[Zigbee Devices]].
+
+\`\`\`javascript
+// This #tag should be ignored
+const x = "#notag";
+\`\`\`
+
+#homeassistant #dashboard
+`);
+
+  writeNote("Notes/Daily/2024-01-15.md", `# Daily Note
+
+Today's tasks and observations.
+
+#daily
+`);
+
+  writeNote("Notes/Recipes/Pasta.md", `---
+title: Pasta Recipe
+tag: cooking, food
+---
+
+# Pasta Recipe
+
+A simple pasta recipe.
+`);
+});
+
+afterAll(() => {
+  rmSync(TEST_ROOT, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Parser tests
+// ---------------------------------------------------------------------------
+
+describe("parser", () => {
+  it("extracts frontmatter", async () => {
+    const { parseFrontmatter } = await import("../src/parser.js");
+    const result = parseFrontmatter(`---
+title: Test
+tags: [a, b]
+---
+
+Content here.`);
+    expect(result.frontmatter.title).toBe("Test");
+    expect(result.frontmatter.tags).toEqual(["a", "b"]);
+    expect(result.content.trim()).toBe("Content here.");
+  });
+
+  it("handles missing frontmatter", async () => {
+    const { parseFrontmatter } = await import("../src/parser.js");
+    const result = parseFrontmatter("# Just a heading\n\nSome content.");
+    expect(result.frontmatter).toEqual({});
+    expect(result.content).toContain("Just a heading");
+  });
+
+  it("extracts inline tags", async () => {
+    const { extractTags } = await import("../src/parser.js");
+    const tags = extractTags("Some text #alpha and #beta-test here", {});
+    expect(tags).toContain("alpha");
+    expect(tags).toContain("beta-test");
+  });
+
+  it("extracts frontmatter tags", async () => {
+    const { extractTags } = await import("../src/parser.js");
+    const tags = extractTags("No inline tags", { tags: ["FooBar", "baz"] });
+    expect(tags).toContain("foobar");
+    expect(tags).toContain("baz");
+  });
+
+  it("extracts comma-separated string tags", async () => {
+    const { extractTags } = await import("../src/parser.js");
+    const tags = extractTags("", { tag: "cooking, food" });
+    expect(tags).toContain("cooking");
+    expect(tags).toContain("food");
+  });
+
+  it("ignores tags inside code blocks", async () => {
+    const { extractTags } = await import("../src/parser.js");
+    const content = "Real #tag here\n```\n#fake\n```\nAnd `#inline_fake`";
+    const tags = extractTags(content, {});
+    expect(tags).toContain("tag");
+    expect(tags).not.toContain("fake");
+    expect(tags).not.toContain("inline_fake");
+  });
+
+  it("extracts wikilinks", async () => {
+    const { extractWikilinks } = await import("../src/parser.js");
+    const links = extractWikilinks("See [[Note A]] and [[Note B|alias]] and [[Note C#heading]].");
+    expect(links).toHaveLength(3);
+    expect(links[0]).toEqual({ target: "Note A", alias: null });
+    expect(links[1]).toEqual({ target: "Note B", alias: "alias" });
+    expect(links[2]).toEqual({ target: "Note C", alias: null });
+  });
+
+  it("deduplicates wikilinks", async () => {
+    const { extractWikilinks } = await import("../src/parser.js");
+    const links = extractWikilinks("[[Dup]] and [[Dup]] again.");
+    expect(links).toHaveLength(1);
+  });
+
+  it("derives title from frontmatter", async () => {
+    const { deriveTitle } = await import("../src/parser.js");
+    expect(deriveTitle({ title: "My Title" }, "# Other", "file.md")).toBe("My Title");
+  });
+
+  it("derives title from H1", async () => {
+    const { deriveTitle } = await import("../src/parser.js");
+    expect(deriveTitle({}, "# Heading Title\n\nContent", "file.md")).toBe("Heading Title");
+  });
+
+  it("derives title from filename", async () => {
+    const { deriveTitle } = await import("../src/parser.js");
+    expect(deriveTitle({}, "No heading", "path/to/My Note.md")).toBe("My Note");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Security tests
+// ---------------------------------------------------------------------------
+
+describe("security", () => {
+  it("resolves a valid path inside vault", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    const result = resolveSafePath(VAULT_ROOT, "Projects/Battery Monitoring.md");
+    expect(result).toBe(join(VAULT_ROOT, "Projects/Battery Monitoring.md"));
+  });
+
+  it("rejects path traversal with ../", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    expect(() => resolveSafePath(VAULT_ROOT, "../../etc/passwd")).toThrow(/escapes vault root/);
+  });
+
+  it("rejects absolute paths", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    expect(() => resolveSafePath(VAULT_ROOT, "/etc/passwd")).toThrow(/absolute paths/);
+  });
+
+  it("rejects null bytes", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    expect(() => resolveSafePath(VAULT_ROOT, "file\0.md")).toThrow(/null bytes/);
+  });
+
+  it("rejects empty path", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    expect(() => resolveSafePath(VAULT_ROOT, "")).toThrow(/empty/);
+  });
+
+  it("validates index location is outside vault", async () => {
+    const { validateIndexLocation } = await import("../src/security.js");
+    expect(() => validateIndexLocation(VAULT_ROOT, join(VAULT_ROOT, "index.db")))
+      .toThrow(/must not be inside vault root/);
+  });
+
+  it("allows index location outside vault", async () => {
+    const { validateIndexLocation } = await import("../src/security.js");
+    expect(() => validateIndexLocation(VAULT_ROOT, INDEX_PATH)).not.toThrow();
+  });
+
+  it("rejects symlink escaping vault", async () => {
+    const { resolveSafePath } = await import("../src/security.js");
+    const linkPath = join(VAULT_ROOT, "escape-link.md");
+    try {
+      symlinkSync("/etc/hostname", linkPath);
+      expect(() => resolveSafePath(VAULT_ROOT, "escape-link.md")).toThrow(/escapes vault root/);
+    } finally {
+      try { rmSync(linkPath); } catch { /* ignore */ }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Indexer tests
+// ---------------------------------------------------------------------------
+
+describe("indexer", () => {
+  let VaultIndex: typeof import("../src/indexer.js").VaultIndex;
+  let index: InstanceType<typeof import("../src/indexer.js").VaultIndex>;
+
+  beforeAll(async () => {
+    const mod = await import("../src/indexer.js");
+    VaultIndex = mod.VaultIndex;
+    index = new VaultIndex({ vaultRoot: VAULT_ROOT, indexLocation: INDEX_PATH });
+    await index.startIndexing();
+  });
+
+  afterAll(async () => {
+    await index.close();
+  });
+
+  it("indexes all markdown files", () => {
+    expect(index.getNoteCount()).toBe(5);
+  });
+
+  it("marks index as ready", () => {
+    expect(index.ready).toBe(true);
+  });
+
+  it("searches for notes", () => {
+    const results = index.search("battery", 10);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].path).toContain("Battery Monitoring");
+  });
+
+  it("returns empty for no-match search", () => {
+    const results = index.search("xyznonexistent123", 10);
+    expect(results).toHaveLength(0);
+  });
+
+  it("reads a note by path", () => {
+    const note = index.readNote("Projects/Battery Monitoring.md");
+    expect(note).not.toBeNull();
+    expect(note!.title).toBe("Battery Monitoring");
+    expect(note!.content).toContain("Monitor battery levels");
+  });
+
+  it("returns null for nonexistent note", () => {
+    const note = index.readNote("nonexistent.md");
+    expect(note).toBeNull();
+  });
+
+  it("lists recent notes", () => {
+    const recent = index.listRecent(3);
+    expect(recent.length).toBeLessThanOrEqual(3);
+    expect(recent.length).toBeGreaterThan(0);
+    // All should have mtime
+    for (const r of recent) {
+      expect(r.mtime_ms).toBeGreaterThan(0);
+    }
+  });
+
+  it("lists all tags", () => {
+    const tags = index.listTags();
+    expect(tags).toContain("homeassistant");
+    expect(tags).toContain("iot");
+    expect(tags).toContain("monitoring");
+    expect(tags).toContain("daily");
+    expect(tags).toContain("cooking");
+  });
+
+  it("does not include code-block tags", () => {
+    const tags = index.listTags();
+    expect(tags).not.toContain("notag");
+  });
+
+  it("finds backlinks", () => {
+    const backlinks = index.getBacklinks("Battery Monitoring");
+    expect(backlinks.length).toBeGreaterThanOrEqual(2);
+    const paths = backlinks.map((b) => b.path);
+    expect(paths).toContain("Projects/Zigbee Devices.md");
+    expect(paths).toContain("Projects/Home Dashboard.md");
+  });
+
+  it("finds related notes", () => {
+    const related = index.getRelatedNotes("Projects/Battery Monitoring.md");
+    expect(related.length).toBeGreaterThan(0);
+    const paths = related.map((r) => r.path);
+    expect(paths).toContain("Projects/Zigbee Devices.md");
+    // Each should have reasons
+    for (const r of related) {
+      expect(r.reasons.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Plugin tool registration
+// ---------------------------------------------------------------------------
+
+describe("plugin entry", () => {
+  it("has correct id and name", async () => {
+    const { createEntry } = await import("../src/index.js");
+    const entry = createEntry();
+    expect(entry.id).toBe("obsidian-vault");
+    expect(entry.name).toBe("Obsidian Vault");
+  });
+
+  it("declares all expected tools in contracts", async () => {
+    const { createEntry } = await import("../src/index.js");
+    const entry = createEntry();
+    expect(entry.contracts.tools.sort()).toEqual([
+      "vault_backlinks",
+      "vault_read",
+      "vault_recent",
+      "vault_related",
+      "vault_search",
+      "vault_tags",
+    ]);
+  });
+
+  it("throws when vaultRoot is not provided", async () => {
+    const { createEntry } = await import("../src/index.js");
+    const entry = createEntry();
+    const api = {
+      pluginConfig: {},
+      registerTool: () => {},
+    };
+    expect(() => entry.register(api)).toThrow(/vaultRoot/);
+  });
+
+  it("registers all tools when valid config is provided", async () => {
+    const { createEntry } = await import("../src/index.js");
+    const entry = createEntry();
+    const tools: Record<string, unknown> = {};
+    const api = {
+      pluginConfig: {
+        vaultRoot: VAULT_ROOT,
+        indexLocation: INDEX_PATH + ".reg-test",
+      },
+      registerTool: (tool: { name: string }) => {
+        tools[tool.name] = tool;
+      },
+    };
+
+    entry.register(api);
+
+    expect(Object.keys(tools).sort()).toEqual([
+      "vault_backlinks",
+      "vault_read",
+      "vault_recent",
+      "vault_related",
+      "vault_search",
+      "vault_tags",
+    ]);
+
+    // Cleanup the index db created during registration
+    try { rmSync(INDEX_PATH + ".reg-test", { force: true }); } catch { /* ignore */ }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler tests (vault_read with security)
+// ---------------------------------------------------------------------------
+
+describe("vault_read handler", () => {
+  it("reads a note successfully", async () => {
+    const { handleRead } = await import("../src/handlers.js");
+    const { VaultIndex } = await import("../src/indexer.js");
+    const idx = new VaultIndex({
+      vaultRoot: VAULT_ROOT,
+      indexLocation: INDEX_PATH + ".read-test",
+    });
+    await idx.startIndexing();
+
+    const result = handleRead(
+      { vaultRoot: VAULT_ROOT, indexLocation: INDEX_PATH + ".read-test" },
+      idx,
+      "Notes/Recipes/Pasta.md",
+    ) as { output: Record<string, unknown> };
+
+    expect(result.output.title).toBe("Pasta Recipe");
+    expect(result.output.tags).toContain("cooking");
+    expect(result.output.tags).toContain("food");
+
+    await idx.close();
+    try { rmSync(INDEX_PATH + ".read-test", { force: true }); } catch { /* ignore */ }
+  });
+
+  it("rejects path traversal", async () => {
+    const { handleRead } = await import("../src/handlers.js");
+    const { VaultIndex } = await import("../src/indexer.js");
+    const idx = new VaultIndex({
+      vaultRoot: VAULT_ROOT,
+      indexLocation: INDEX_PATH + ".trav-test",
+    });
+
+    const result = handleRead(
+      { vaultRoot: VAULT_ROOT, indexLocation: INDEX_PATH + ".trav-test" },
+      idx,
+      "../../etc/passwd",
+    ) as { error: string };
+
+    expect(result.error).toContain("Access denied");
+
+    await idx.close();
+    try { rmSync(INDEX_PATH + ".trav-test", { force: true }); } catch { /* ignore */ }
+  });
+
+  it("returns error for nonexistent note", async () => {
+    const { handleRead } = await import("../src/handlers.js");
+    const { VaultIndex } = await import("../src/indexer.js");
+    const idx = new VaultIndex({
+      vaultRoot: VAULT_ROOT,
+      indexLocation: INDEX_PATH + ".noent-test",
+    });
+
+    const result = handleRead(
+      { vaultRoot: VAULT_ROOT, indexLocation: INDEX_PATH + ".noent-test" },
+      idx,
+      "nonexistent.md",
+    ) as { error: string };
+
+    expect(result.error).toContain("not found");
+
+    await idx.close();
+    try { rmSync(INDEX_PATH + ".noent-test", { force: true }); } catch { /* ignore */ }
+  });
+});

--- a/plugins/obsidian-vault/tsconfig.json
+++ b/plugins/obsidian-vault/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "tests",
+    "vitest.config.ts",
+    "dist",
+    "node_modules"
+  ]
+}

--- a/plugins/obsidian-vault/tsup.config.ts
+++ b/plugins/obsidian-vault/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/adapter.ts", "src/handlers.ts", "src/indexer.ts", "src/security.ts", "src/parser.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  target: "node20",
+  splitting: false,
+  shims: false,
+  skipNodeModulesBundle: true,
+});

--- a/plugins/obsidian-vault/vitest.config.ts
+++ b/plugins/obsidian-vault/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Obsidian Vault Plugin

Implements [octo#146](https://github.com/JeffSteinbok/octo/issues/146) — a secure OpenClaw plugin providing read-only access to an Obsidian vault on the local filesystem.

### Tools

| Tool | Description |
|------|-------------|
| `vault_search` | Full-text search via SQLite FTS5 with ranked snippets |
| `vault_read` | Read note with parsed frontmatter, tags, and wikilinks |
| `vault_recent` | List recently modified notes |
| `vault_tags` | List all tags across the vault |
| `vault_backlinks` | Find notes linking to a target via `[[wikilinks]]` |
| `vault_related` | Related notes via shared links and tags |

### Example config

```json
{
  "plugins": {
    "entries": {
      "obsidian-vault": {
        "enabled": true,
        "config": {
          "vaultRoot": "/home/openclaw/OneDrive/JeffBrain",
          "indexLocation": "~/.openclaw/obsidian-index.db"
        }
      }
    }
  }
}
```

### Security

- Path traversal prevention via `realpath` confinement
- Symlink escape rejection
- Index location validated to be outside vault root
- Read-only — no write operations on vault files

### Architecture

- **SQLite FTS5** for full-text search with ranking and snippets
- **chokidar** file watcher for incremental index updates (picks up OneDrive syncs)
- **gray-matter** for YAML frontmatter parsing
- Code-block-aware tag and wikilink extraction
- Batched indexing with event loop yielding for large vaults

### Tests

37 tests covering parsing, security, indexing, handlers, and tool registration.