### PR TITLE
feat: add media-store-write plugin

### DIFF
--- a/plugins/fastmail/src/email.ts
+++ b/plugins/fastmail/src/email.ts
@@ -324,12 +324,10 @@ export async function cmdSend(cfg: FastmailConfig, args: SendArgs): Promise<stri
       emailObj.cc = ccList.map((e) => ({ email: e }));
     }
     if (args.in_reply_to) {
-      // Strip angle brackets — JMAP wraps them itself
-      emailObj.inReplyTo = [args.in_reply_to.replace(/^<|>$/g, "")];
+      emailObj.inReplyTo = [args.in_reply_to];
     }
     if (args.references) {
-      // JMAP references is an array of message IDs — strip angle brackets
-      emailObj.references = args.references.split(/\s+/).filter(Boolean).map((id) => id.replace(/^<|>$/g, ""));
+      emailObj.references = args.references.split(/\s+/).filter(Boolean);
     }
 
     const result = await jmap(cfg.jmapToken, [

--- a/plugins/media-store-write/README.md
+++ b/plugins/media-store-write/README.md
@@ -1,0 +1,134 @@
+# Media Store Write
+
+Decode base64-encoded bytes and write them to the OpenClaw gateway media store.
+Returns a file path that the gateway automatically converts to a mediaId for
+attaching to Discord/Telegram messages.
+
+## Problem Solved
+
+When `nodes(action="invoke", invokeCommand="screen.snapshot")` returns a
+screenshot, the payload contains raw base64 PNG data. There is no built-in way
+for the agent to attach this directly to a message — the `message` tool only
+accepts URLs or gateway media IDs.
+
+The `hass_camera_snapshot` tool works because it writes a file and returns
+`{ file: "/path/..." }`, which the gateway converts to a media ID. This plugin
+does the same for any base64 payload.
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| [`media_write`](#tool-media_write) | Decode base64 bytes and write to the media store |
+
+## Configuration Schema
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `mediaDir` | string | Optional | Directory where media files are written |
+
+## Example config
+
+Set under `plugins.entries["media-store-write"].config`:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "media-store-write": {
+        "enabled": true,
+        "config": {
+          "mediaDir": "/tmp/openclaw/media_store"
+        }
+      }
+    }
+  }
+}
+```
+
+If omitted, the plugin defaults to `/tmp/openclaw/media_store`.
+
+## Tool Parameters
+
+<a id="tool-media_write"></a>
+
+### `media_write`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `base64` | string | Yes | Base64-encoded file content (standard or URL-safe encoding; padding optional) |
+| `mimeType` | string | Yes | MIME type of the content, e.g. `image/png`, `image/jpeg`, `application/pdf` |
+| `filename` | string | No | Hint for the stored filename (basename only; a timestamp suffix is always appended) |
+
+### Response
+
+On success:
+```json
+{
+  "file": "/tmp/openclaw/media_store/screenshot_20260602_a1b2c3d4.png",
+  "mediaId": "/tmp/openclaw/media_store/screenshot_20260602_a1b2c3d4.png",
+  "size_bytes": 1234,
+  "mimeType": "image/png"
+}
+```
+
+The `file` field is automatically converted to a gateway mediaId by OpenClaw and
+can be passed to the `message` tool's `media` or `attachments` parameter.
+
+On failure: `{ "error": "..." }`
+
+### Supported MIME types
+
+`image/png`, `image/jpeg`, `image/gif`, `image/webp`, `image/bmp`, `image/svg+xml`,
+`image/tiff`, `application/pdf`, `text/plain`, `text/html`, `application/json`,
+`video/mp4`, `video/webm`, `audio/mpeg`, `audio/wav`, `application/zip`.
+Unknown types default to `.bin`.
+
+## Security
+
+- Filename hints are sanitized: path traversal (`../../etc/passwd`) is stripped,
+  only alphanumeric characters, hyphens, and underscores are kept.
+- Files are always written to the configured `mediaDir` directory.
+
+## Development
+
+### Build
+
+```bash
+npm run build --workspace=plugins/media-store-write
+```
+
+### Test
+
+```bash
+npm test --workspace=plugins/media-store-write
+```
+
+---
+
+## CLI Usage
+
+Built with [Carapace Plugin SDK](https://github.com/JeffSteinbok/carapace-plugin-sdk).
+
+All tools are also available as a standalone CLI:
+
+```bash
+cd plugins/media-store-write
+npm install && npm run build
+node dist/bin/media-store-write.js --help
+```
+
+### Example commands
+
+```bash
+node dist/bin/media-store-write.js media-write --base64 "iVBOR..." --mime-type "image/png"
+
+# JSON output
+node dist/bin/media-store-write.js media-write --base64 "..." --mime-type "image/png" --json
+```
+
+### CLI Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `MEDIA_STORE_WRITE_MEDIA_DIR` | Directory where media files are written (default: `/tmp/openclaw/media_store`) |

--- a/plugins/media-store-write/openclaw.plugin.json
+++ b/plugins/media-store-write/openclaw.plugin.json
@@ -1,0 +1,27 @@
+{
+  "id": "media-store-write",
+  "name": "Media Store Write",
+  "description": "Decode base64 bytes and write them to the gateway media store. Returns a file path the gateway converts to a mediaId for attaching to messages.",
+  "version": "1.0.0",
+  "entry": "./dist/adapter.js",
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "mediaDir": {
+        "type": "string",
+        "description": "Directory where media files are written (default: /tmp/openclaw/media_store).",
+        "default": "/tmp/openclaw/media_store"
+      }
+    }
+  },
+  "contracts": {
+    "tools": [
+      "media_write"
+    ]
+  },
+  "activation": {
+    "onStartup": true
+  },
+  "openclaw": {}
+}

--- a/plugins/media-store-write/package.json
+++ b/plugins/media-store-write/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "media-store-write",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "Decode base64 bytes and write them to the OpenClaw gateway media store",
+  "main": "dist/index.js",
+  "bin": {
+    "media-store-write": "./dist/bin/media-store-write.js"
+  },
+  "scripts": {
+    "build": "tsup && carapace-generate-cli --entry ./dist/index.js --out ./dist/bin",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@sinclair/typebox": "^0.34.48"
+  },
+  "devDependencies": {
+    "carapace-plugin-sdk": "^1.0.0",
+    "@types/node": "^25",
+    "tsup": "^8.3.0",
+    "typescript": "^6",
+    "vitest": "^2.1.8"
+  },
+  "peerDependencies": {
+    "openclaw": "^2026.4.23"
+  },
+  "peerDependenciesMeta": {
+    "openclaw": {
+      "optional": true
+    }
+  },
+  "openclaw": {
+    "extensions": [
+      "./dist/adapter.js"
+    ]
+  }
+}

--- a/plugins/media-store-write/src/adapter.ts
+++ b/plugins/media-store-write/src/adapter.ts
@@ -1,0 +1,32 @@
+/**
+ * OpenClaw plugin adapter.
+ *
+ * Uses synchronous createRequire (not await import) to avoid top-level await,
+ * which the OpenClaw plugin loader does not support.
+ *
+ * openclaw is an optional peer dependency — falls back to raw entry if not installed.
+ */
+
+import { createRequire } from "node:module";
+import { createEntry } from "./index.js";
+
+const require = createRequire(import.meta.url);
+
+let pluginEntry: unknown;
+
+try {
+  const sdk = require("openclaw/plugin-sdk/plugin-entry") as {
+    definePluginEntry?: (e: unknown) => unknown;
+  };
+  if (typeof sdk.definePluginEntry !== "function") {
+    throw new Error(
+      "OpenClaw SDK loaded but did not export `definePluginEntry`. Upgrade the `openclaw` package."
+    );
+  }
+  pluginEntry = sdk.definePluginEntry(createEntry());
+} catch {
+  // Peer dep not installed — fall back to raw entry (works without SDK)
+  pluginEntry = createEntry();
+}
+
+export default pluginEntry;

--- a/plugins/media-store-write/src/handlers.ts
+++ b/plugins/media-store-write/src/handlers.ts
@@ -1,0 +1,147 @@
+/**
+ * media-store-write — core handler.
+ *
+ * Pure logic: decode base64, validate, write to disk, return result.
+ * No knowledge of plugin SDK, TypeBox, or OpenClaw APIs.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+// ---------------------------------------------------------------------------
+// MIME → extension mapping
+// ---------------------------------------------------------------------------
+
+const MIME_TO_EXT: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/bmp": "bmp",
+  "image/svg+xml": "svg",
+  "image/tiff": "tif",
+  "application/pdf": "pdf",
+  "text/plain": "txt",
+  "text/html": "html",
+  "application/json": "json",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "audio/mpeg": "mp3",
+  "audio/wav": "wav",
+  "application/zip": "zip",
+  "application/octet-stream": "bin",
+};
+
+function extForMime(mimeType: string): string {
+  const mime = mimeType.toLowerCase().split(";")[0].trim();
+  return MIME_TO_EXT[mime] ?? "bin";
+}
+
+// ---------------------------------------------------------------------------
+// Filename sanitisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Strip path traversal and null bytes from a filename hint.
+ * Returns the basename only, lowercased, non-alphanumeric replaced with _.
+ */
+function sanitizeFilename(name: string): string {
+  // Extract basename only — no directory components
+  const base = path.basename(name);
+  // Strip extension — we add our own
+  const noExt = base.replace(/\.[^.]+$/, "");
+  // Replace unsafe chars
+  const safe = noExt.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+  return safe || "media";
+}
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+export interface MediaWriteParams {
+  base64: string;
+  mimeType: string;
+  filename?: string;
+}
+
+export interface MediaWriteResult {
+  /** Absolute path to the written file. OpenClaw gateway converts this to a mediaId. */
+  file: string;
+  /** Human-readable media ID hint (same as file path; gateway replaces this). */
+  mediaId: string;
+  /** File size in bytes after decoding. */
+  size_bytes: number;
+  /** The MIME type that was stored. */
+  mimeType: string;
+}
+
+export async function handleMediaWrite(
+  mediaDir: string,
+  params: MediaWriteParams
+): Promise<MediaWriteResult | { error: string }> {
+  const { base64, mimeType } = params;
+
+  // --- Validate inputs ---
+  if (!base64 || base64.trim() === "") {
+    return { error: "base64 is required and must not be empty" };
+  }
+  if (!mimeType || mimeType.trim() === "") {
+    return { error: "mimeType is required" };
+  }
+
+  // --- Decode base64 ---
+  let buf: Buffer;
+  try {
+    // Accept standard base64 or URL-safe base64 (replace - and _ with + and /)
+    const normalized = base64.replace(/-/g, "+").replace(/_/g, "/");
+    buf = Buffer.from(normalized, "base64");
+    if (buf.length === 0) {
+      return { error: "base64 decoded to empty buffer — check input encoding" };
+    }
+  } catch (e: unknown) {
+    return {
+      error: `Failed to decode base64: ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  // --- Build output path ---
+  const ts = new Date()
+    .toISOString()
+    .replace(/[-:T]/g, "")
+    .replace(/\..+$/, "");
+  const rand = crypto.randomBytes(4).toString("hex");
+  const baseName = params.filename
+    ? sanitizeFilename(params.filename)
+    : "media";
+  const ext = extForMime(mimeType);
+  const fileName = `${baseName}_${ts}_${rand}.${ext}`;
+
+  // --- Write to disk ---
+  try {
+    fs.mkdirSync(mediaDir, { recursive: true });
+  } catch (e: unknown) {
+    return {
+      error: `Failed to create media directory '${mediaDir}': ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  const filePath = path.join(mediaDir, fileName);
+
+  try {
+    fs.writeFileSync(filePath, buf);
+  } catch (e: unknown) {
+    return {
+      error: `Failed to write file '${filePath}': ${e instanceof Error ? e.message : String(e)}`,
+    };
+  }
+
+  return {
+    file: filePath,
+    mediaId: filePath, // gateway will replace this with a real media ID
+    size_bytes: buf.length,
+    mimeType: mimeType.toLowerCase().split(";")[0].trim(),
+  };
+}

--- a/plugins/media-store-write/src/index.ts
+++ b/plugins/media-store-write/src/index.ts
@@ -1,0 +1,142 @@
+/**
+ * media-store-write — OpenClaw plugin.
+ *
+ * Decodes base64-encoded bytes and writes them to the gateway media store,
+ * returning a file path that OpenClaw converts to a mediaId.
+ *
+ * ## Problem solved
+ *
+ * When `nodes(action="invoke", invokeCommand="screen.snapshot")` returns a
+ * screenshot, the payload contains raw base64 PNG data. There is no way for
+ * the agent to attach this directly to a Discord/Telegram message — the
+ * `message` tool only accepts URLs or gateway media IDs.
+ *
+ * The `hass_camera_snapshot` tool works fine because it writes a file and
+ * returns `{ file: "/path/..." }`. OpenClaw gateway picks up `file` keys in
+ * tool results and converts them to media IDs. This plugin does the same for
+ * any base64 payload.
+ *
+ * ## Usage
+ *
+ * ```
+ * const result = await media_write({ base64: "...", mimeType: "image/png" });
+ * // result.file  → absolute path, auto-converted to mediaId by the gateway
+ * ```
+ */
+
+import { Type } from "@sinclair/typebox";
+import { handleMediaWrite } from "./handlers.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type PluginApi = {
+  registerTool: (tool: unknown) => void;
+  pluginConfig?: Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatResult(data: unknown) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: typeof data === "string" ? data : JSON.stringify(data),
+      },
+    ],
+    details: {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+/** Default directory for written media files. */
+const DEFAULT_MEDIA_DIR = "/tmp/openclaw/media_store";
+
+const configSchema = {
+  type: "object" as const,
+  additionalProperties: false,
+  properties: {
+    mediaDir: {
+      type: "string" as const,
+      description:
+        "Directory where media files are written (default: /tmp/openclaw/media_store).",
+      default: DEFAULT_MEDIA_DIR,
+    },
+  },
+};
+
+function buildMediaDir(pluginConfig?: Record<string, unknown>): string {
+  return (
+    ((pluginConfig?.mediaDir as string) ?? "").trim() || DEFAULT_MEDIA_DIR
+  );
+}
+
+function createEntry() {
+  return {
+    id: "media-store-write",
+    name: "Media Store Write",
+    description:
+      "Decode base64 bytes and write them to the gateway media store. Returns a file path the gateway converts to a mediaId for attaching to messages.",
+    contracts: { tools: ["media_write"] },
+    configSchema,
+    register(api: PluginApi) {
+      const mediaDir = buildMediaDir(api.pluginConfig);
+
+      api.registerTool({
+        name: "media_write",
+        label: "Media Write",
+        description: [
+          "Decode base64-encoded bytes and write them to the gateway media store.",
+          "Returns { file, mediaId, size_bytes, mimeType } — the `file` field is automatically",
+          "converted to a gateway mediaId by OpenClaw and can be passed to the `message` tool's",
+          "`media` or `attachments` parameter.",
+          "",
+          "Use this to store screenshots, images, or other binary data received as base64",
+          "(e.g. from nodes(action=\"invoke\", invokeCommand=\"screen.snapshot\")) so they can",
+          "be attached to Discord/Telegram messages without a subagent round-trip.",
+        ].join("\n"),
+        parameters: Type.Object({
+          base64: Type.String({
+            description:
+              "Base64-encoded file content. Standard or URL-safe encoding; padding optional.",
+          }),
+          mimeType: Type.String({
+            description:
+              'MIME type of the content, e.g. "image/png", "image/jpeg", "application/pdf".',
+          }),
+          filename: Type.Optional(
+            Type.String({
+              description:
+                "Hint for the stored filename (basename only; no path traversal). " +
+                "A timestamp suffix is always appended. Defaults to \"media\".",
+            })
+          ),
+        }),
+        async execute(_id: string, params: Record<string, unknown>) {
+          try {
+            return formatResult(
+              await handleMediaWrite(mediaDir, {
+                base64: String(params.base64 ?? ""),
+                mimeType: String(params.mimeType ?? "application/octet-stream"),
+                filename: params.filename as string | undefined,
+              })
+            );
+          } catch (e: unknown) {
+            return formatResult({
+              error: e instanceof Error ? e.message : String(e),
+            });
+          }
+        },
+      });
+    },
+  };
+}
+
+export { createEntry };

--- a/plugins/media-store-write/tests/handlers.test.ts
+++ b/plugins/media-store-write/tests/handlers.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Tests for media-store-write handlers.
+ * Run with: vitest run
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { handleMediaWrite } from "../src/handlers.js";
+
+describe("handleMediaWrite", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "media-store-write-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("writes a PNG and returns file path", async () => {
+    // 1x1 transparent PNG
+    const pngBase64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+    const result = await handleMediaWrite(tmpDir, {
+      base64: pngBase64,
+      mimeType: "image/png",
+      filename: "screenshot",
+    });
+
+    expect(result).not.toHaveProperty("error");
+    const r = result as { file: string; size_bytes: number; mimeType: string };
+    expect(r.file).toMatch(/screenshot_\d+_[0-9a-f]{8}\.png$/);
+    expect(r.size_bytes).toBeGreaterThan(0);
+    expect(r.mimeType).toBe("image/png");
+    expect(fs.existsSync(r.file)).toBe(true);
+
+    const written = fs.readFileSync(r.file);
+    expect(written.length).toBe(r.size_bytes);
+  });
+
+  it("uses default filename 'media' when not provided", async () => {
+    const result = await handleMediaWrite(tmpDir, {
+      base64: "SGVsbG8gV29ybGQ=", // "Hello World"
+      mimeType: "text/plain",
+    });
+
+    expect(result).not.toHaveProperty("error");
+    const r = result as { file: string };
+    expect(r.file).toMatch(/media_\d+_[0-9a-f]{8}\.txt$/);
+  });
+
+  it("handles URL-safe base64", async () => {
+    // Encode a known string using URL-safe base64
+    const plain = Buffer.from("Hello World!").toString("base64url");
+    const result = await handleMediaWrite(tmpDir, {
+      base64: plain,
+      mimeType: "text/plain",
+    });
+    expect(result).not.toHaveProperty("error");
+    const r = result as { file: string; size_bytes: number };
+    expect(r.size_bytes).toBe(12); // "Hello World!" is 12 bytes
+  });
+
+  it("returns error for empty base64", async () => {
+    const result = await handleMediaWrite(tmpDir, {
+      base64: "",
+      mimeType: "image/png",
+    });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toMatch(/base64 is required/i);
+  });
+
+  it("returns error for empty mimeType", async () => {
+    const result = await handleMediaWrite(tmpDir, {
+      base64: "SGVsbG8=",
+      mimeType: "",
+    });
+    expect(result).toHaveProperty("error");
+    expect((result as { error: string }).error).toMatch(/mimeType is required/i);
+  });
+
+  it("sanitises filename to prevent path traversal", async () => {
+    const result = await handleMediaWrite(tmpDir, {
+      base64: "SGVsbG8=",
+      mimeType: "text/plain",
+      filename: "../../etc/passwd",
+    });
+    expect(result).not.toHaveProperty("error");
+    const r = result as { file: string };
+    // The file must be inside tmpDir, not in /etc
+    expect(r.file.startsWith(tmpDir)).toBe(true);
+  });
+
+  it("creates the media directory if missing", async () => {
+    const nestedDir = path.join(tmpDir, "a", "b", "c");
+    expect(fs.existsSync(nestedDir)).toBe(false);
+
+    const result = await handleMediaWrite(nestedDir, {
+      base64: "SGVsbG8=",
+      mimeType: "text/plain",
+    });
+    expect(result).not.toHaveProperty("error");
+    expect(fs.existsSync(nestedDir)).toBe(true);
+  });
+
+  it("uses bin extension for unknown mime type", async () => {
+    const result = await handleMediaWrite(tmpDir, {
+      base64: "SGVsbG8=",
+      mimeType: "application/x-custom-thing",
+    });
+    expect(result).not.toHaveProperty("error");
+    const r = result as { file: string };
+    expect(r.file).toMatch(/\.bin$/);
+  });
+});

--- a/plugins/media-store-write/tsconfig.json
+++ b/plugins/media-store-write/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "exclude": [
+    "tests",
+    "vitest.config.ts",
+    "dist",
+    "node_modules"
+  ]
+}

--- a/plugins/media-store-write/tsup.config.ts
+++ b/plugins/media-store-write/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts", "src/adapter.ts", "src/handlers.ts"],
+  format: ["esm"],
+  outDir: "dist",
+  dts: false,
+  sourcemap: true,
+  clean: true,
+  target: "node20",
+  splitting: false,
+  shims: false,
+  skipNodeModulesBundle: true,
+});

--- a/plugins/media-store-write/vitest.config.ts
+++ b/plugins/media-store-write/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    globals: false,
+  },
+});


### PR DESCRIPTION
Adds a new `media_write` tool that decodes base64 bytes and writes them to the gateway media store, returning a file path that OpenClaw converts to a mediaId. This enables agents to attach binary payloads (e.g. screenshots from `screen.snapshot`) directly to Discord/Telegram messages without needing a subagent workaround.