### PR TITLE
fix: remove direct process.env reads from mail_action_usps lib

### DIFF
--- a/libs/ts/mail_action_usps/src/analyze.ts
+++ b/libs/ts/mail_action_usps/src/analyze.ts
@@ -77,6 +77,10 @@ export interface ProcessDigestOptions {
   workspaceAgent?: string;
   memoryAgent?: string;
   visionAgent?: string;
+  /** Fallback notification channel when routing config has no default. */
+  defaultChannel?: string;
+  /** Fallback notification target when routing config has no default. */
+  defaultTarget?: string;
 }
 
 /**
@@ -99,6 +103,8 @@ export async function processDigest(
     workspaceAgent,
     memoryAgent,
     visionAgent,
+    defaultChannel,
+    defaultTarget,
   } = options;
 
   if (!workspaceAgent) {
@@ -194,13 +200,15 @@ export async function processDigest(
   const notificationPlan = buildNotificationPlan(
     dateStr,
     Object.values(items),
-    { workspaceAgent },
+    { workspaceAgent, defaultChannel, defaultTarget },
   );
   let notifications: unknown[] = [];
   if (sendNotifications) {
     notifications = routeAndNotify(dateStr, Object.values(items), {
       dryRun,
       workspaceAgent,
+      defaultChannel,
+      defaultTarget,
     });
   }
 

--- a/libs/ts/mail_action_usps/src/notify.ts
+++ b/libs/ts/mail_action_usps/src/notify.ts
@@ -94,6 +94,10 @@ export function buildNotificationPlan(
   options?: {
     config?: Record<string, unknown>;
     workspaceAgent?: string;
+    /** Fallback notification channel when routing config has no default. */
+    defaultChannel?: string;
+    /** Fallback notification target when routing config has no default. */
+    defaultTarget?: string;
   },
 ): NotificationEntry[] {
   const opts = options ?? {};
@@ -112,8 +116,8 @@ export function buildNotificationPlan(
   if (!routing || Object.keys(routing).length === 0) {
     routing = {
       default: {
-        channel: process.env.NOTIFY_CHANNEL ?? "discord",
-        target: process.env.NOTIFY_TARGET ?? "",
+        channel: opts.defaultChannel ?? defaultChannel,
+        target: opts.defaultTarget ?? "",
       },
     };
   }
@@ -187,7 +191,7 @@ export function buildNotificationPlan(
 export function routeAndNotify(
   dateStr: string,
   items: Array<Record<string, unknown>>,
-  options?: { dryRun?: boolean; workspaceAgent?: string },
+  options?: { dryRun?: boolean; workspaceAgent?: string; defaultChannel?: string; defaultTarget?: string },
 ): NotificationEntry[] {
   const opts = options ?? {};
   if (!opts.workspaceAgent) {
@@ -195,6 +199,8 @@ export function routeAndNotify(
   }
   const plan = buildNotificationPlan(dateStr, items, {
     workspaceAgent: opts.workspaceAgent,
+    defaultChannel: opts.defaultChannel,
+    defaultTarget: opts.defaultTarget,
   });
   const results: NotificationEntry[] = [];
   for (const entry of plan) {

--- a/libs/ts/mail_action_usps/src/register.ts
+++ b/libs/ts/mail_action_usps/src/register.ts
@@ -90,6 +90,8 @@ export async function processUspsDigestAction(
     workspaceAgent: params.workspace_agent as string,
     memoryAgent: params.memory_agent as string,
     visionAgent: params.vision_agent as string,
+    defaultChannel: params.notify_channel as string | undefined,
+    defaultTarget: params.notify_target as string | undefined,
   });
 
   if (result.error) {


### PR DESCRIPTION
## Summary

Remove direct `process.env` reads from the `mail_action_usps` library. The lib was reading `NOTIFY_CHANNEL` and `NOTIFY_TARGET` directly in `buildNotificationPlan` as fallback defaults when routing config is absent. This creates hidden env coupling and makes the lib harder to test.

**Changes:**
- `libs/ts/mail_action_usps/src/notify.ts`: Add `defaultChannel` and `defaultTarget` optional params to `buildNotificationPlan` options; replace `process.env` reads with these params (falling back to `"discord"` / `""`)
- `libs/ts/mail_action_usps/src/notify.ts`: Propagate `defaultChannel`/`defaultTarget` through `routeAndNotify` options
- `libs/ts/mail_action_usps/src/analyze.ts`: Add `defaultChannel`/`defaultTarget` to `ProcessDigestOptions`; destructure and pass down to `buildNotificationPlan`/`routeAndNotify`
- `libs/ts/mail_action_usps/src/register.ts`: Read `notify_channel`/`notify_target` from action `params` and pass as `defaultChannel`/`defaultTarget` to `processDigest`

All env var access remains in the service layer (`fastmail-sse-ts/src/index.ts`); the lib itself is now pure and testable.

## Resolves
Closes JeffSteinbok/octo#112