### PR TITLE
feat(outlook-mail): add send, reply, forward, move, and flag tools

### DIFF
--- a/plugins/outlook-mail/package.json
+++ b/plugins/outlook-mail/package.json
@@ -1,6 +1,6 @@
 {
   "name": "outlook-mail",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "main": "dist/index.js",
   "bin": {

--- a/plugins/outlook-mail/src/handlers.ts
+++ b/plugins/outlook-mail/src/handlers.ts
@@ -46,20 +46,94 @@ function httpGet(url: string, token: string): Promise<string> {
   });
 }
 
+function httpPostJson(url: string, body: string, token: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string | number> = {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    };
+    const req = https.request(url, { method: "POST", headers: headers as Record<string, string>, timeout: 30_000 }, res => {
+      let data = ""; res.on("data", (c: Buffer) => data += c); res.on("end", () => resolve(data));
+    });
+    req.on("error", reject); req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); });
+    req.write(body); req.end();
+  });
+}
+
+function httpPostEmpty(url: string, token: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Length": "0" },
+      timeout: 30_000,
+    }, res => {
+      res.resume();
+      res.on("end", () => {
+        if ((res.statusCode ?? 0) >= 400) reject(new Error(`HTTP ${res.statusCode}`));
+        else resolve();
+      });
+    });
+    req.on("error", reject); req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); }); req.end();
+  });
+}
+
+function httpPatch(url: string, body: string, token: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const headers: Record<string, string | number> = {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    };
+    const req = https.request(url, { method: "PATCH", headers: headers as Record<string, string>, timeout: 30_000 }, res => {
+      let data = ""; res.on("data", (c: Buffer) => data += c); res.on("end", () => resolve(data));
+    });
+    req.on("error", reject); req.on("timeout", () => { req.destroy(); reject(new Error("timeout")); });
+    req.write(body); req.end();
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Token / Graph
 // ---------------------------------------------------------------------------
 
-async function getToken(clientId: string, clientSecret: string, refreshToken: string, scope = "Mail.Read"): Promise<string> {
-  const body = new URLSearchParams({ client_id: clientId, client_secret: clientSecret, refresh_token: refreshToken, grant_type: "refresh_token", scope }).toString();
+async function getToken(
+  clientId: string,
+  clientSecret: string,
+  refreshToken: string,
+  scope = "Mail.Read Mail.Send Mail.ReadWrite",
+): Promise<string> {
+  const body = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+    scope,
+  }).toString();
   const res = await httpPost(TOKEN_URL, body, { "Content-Type": "application/x-www-form-urlencoded" });
   const data = JSON.parse(res);
-  if (!data.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(data).slice(0, 200)}`);
+  if (!data.access_token) throw new Error(`Token refresh failed: ${JSON.stringify(data).slice(0, 300)}`);
   return data.access_token;
 }
 
 async function graphGet(token: string, path: string): Promise<unknown> {
   const res = await httpGet(`${GRAPH_BASE}${path}`, token);
+  return JSON.parse(res);
+}
+
+async function graphPost(token: string, path: string, body: unknown): Promise<unknown> {
+  const bodyStr = JSON.stringify(body);
+  const res = await httpPostJson(`${GRAPH_BASE}${path}`, bodyStr, token);
+  if (!res || res.trim() === "") return { success: true };
+  return JSON.parse(res);
+}
+
+async function graphPatch(token: string, path: string, body: unknown): Promise<unknown> {
+  const bodyStr = JSON.stringify(body);
+  const res = await httpPatch(`${GRAPH_BASE}${path}`, bodyStr, token);
+  if (!res || res.trim() === "") return { success: true };
   return JSON.parse(res);
 }
 
@@ -72,7 +146,8 @@ function esc(s: string): string { return s.replace(/'/g, "''"); }
 function formatMessage(m: Record<string, unknown>, includeBody = false): Record<string, unknown> {
   const from = (m.from as Record<string, Record<string, string>>)?.emailAddress ?? {};
   const result: Record<string, unknown> = {
-    id: m.id, subject: m.subject ?? "(no subject)",
+    id: m.id,
+    subject: m.subject ?? "(no subject)",
     from: `${from.name ?? ""}${from.address ? ` <${from.address}>` : ""}`.trim(),
     received: String(m.receivedDateTime ?? "").slice(0, 10),
     is_read: m.isRead,
@@ -83,7 +158,7 @@ function formatMessage(m: Record<string, unknown>, includeBody = false): Record<
 }
 
 // ---------------------------------------------------------------------------
-// Handlers
+// Read handlers
 // ---------------------------------------------------------------------------
 
 export async function getInbox(
@@ -163,4 +238,157 @@ export async function saveAttachments(
     saved.push(dest);
   }
   return { saved, count: saved.length };
+}
+
+// ---------------------------------------------------------------------------
+// Send / Reply / Forward / Move / Flag handlers
+// ---------------------------------------------------------------------------
+
+export async function sendMessage(
+  config: OutlookMailConfig,
+  params: {
+    to: string | string[];
+    cc?: string[];
+    subject: string;
+    body: string;
+    signature?: string;
+    attachment?: string[];
+    in_reply_to?: string;
+    references?: string;
+  },
+): Promise<unknown> {
+  const { clientId, clientSecret, refreshToken } = config;
+  if (!clientId) return { error: "OUTLOOK_CLIENT_ID not set" };
+  if (!params.subject?.trim()) return { error: "subject is required" };
+  if (!params.body?.trim()) return { error: "body is required" };
+
+  const token = await getToken(clientId, clientSecret, refreshToken);
+  const toList = Array.isArray(params.to) ? params.to : [params.to];
+  if (!toList.length) return { error: "to is required" };
+
+  const bodyText = params.signature ? `${params.body}\n\n${params.signature}` : params.body;
+  const message: Record<string, unknown> = {
+    subject: params.subject,
+    body: { contentType: "Text", content: bodyText },
+    toRecipients: toList.map(e => ({ emailAddress: { address: e.trim() } })),
+  };
+  if (params.cc?.length) {
+    message.ccRecipients = params.cc.map(e => ({ emailAddress: { address: e.trim() } }));
+  }
+  if (params.in_reply_to) {
+    message.internetMessageHeaders = [{ name: "In-Reply-To", value: params.in_reply_to }];
+  }
+
+  if (params.attachment?.length) {
+    const { readFile } = await import("node:fs/promises");
+    const { basename } = await import("node:path");
+    const attachments: Array<Record<string, unknown>> = [];
+    for (const filepath of params.attachment) {
+      const data = await readFile(filepath);
+      attachments.push({
+        "@odata.type": "#microsoft.graph.fileAttachment",
+        name: basename(filepath),
+        contentBytes: data.toString("base64"),
+      });
+    }
+    message.attachments = attachments;
+  }
+
+  // Create draft message then send it
+  const createRes = await graphPost(token, "/me/messages", message) as Record<string, unknown>;
+  if (createRes.error) return { error: JSON.stringify(createRes.error) };
+  const msgId = String(createRes.id ?? "");
+  if (!msgId) return { error: "Failed to create draft message" };
+
+  await httpPostEmpty(`${GRAPH_BASE}/me/messages/${encodeURIComponent(msgId)}/send`, token);
+
+  const attNote = params.attachment?.length ? ` (${params.attachment.length} attachment(s))` : "";
+  return { ok: true, message: `✓ Sent to ${toList.join(", ")}: ${params.subject}${attNote}` };
+}
+
+export async function replyToMessage(
+  config: OutlookMailConfig,
+  params: {
+    message_id: string;
+    body: string;
+    reply_all?: boolean;
+    signature?: string;
+  },
+): Promise<unknown> {
+  const { clientId, clientSecret, refreshToken } = config;
+  if (!clientId) return { error: "OUTLOOK_CLIENT_ID not set" };
+  const msgId = params.message_id?.trim();
+  if (!msgId) return { error: "message_id is required" };
+  if (!params.body?.trim()) return { error: "body is required" };
+
+  const token = await getToken(clientId, clientSecret, refreshToken);
+  const bodyText = params.signature ? `${params.body}\n\n${params.signature}` : params.body;
+  const endpoint = params.reply_all
+    ? `/me/messages/${encodeURIComponent(msgId)}/replyAll`
+    : `/me/messages/${encodeURIComponent(msgId)}/reply`;
+
+  const payload = {
+    message: { body: { contentType: "Text", content: bodyText } },
+    comment: bodyText,
+  };
+  const res = await graphPost(token, endpoint, payload) as Record<string, unknown>;
+  if (res.error) return { error: JSON.stringify(res.error) };
+  return { ok: true, message: `✓ Reply sent${params.reply_all ? " (reply-all)" : ""}` };
+}
+
+export async function forwardMessage(
+  config: OutlookMailConfig,
+  params: {
+    message_id: string;
+    to: string | string[];
+    comment?: string;
+  },
+): Promise<unknown> {
+  const { clientId, clientSecret, refreshToken } = config;
+  if (!clientId) return { error: "OUTLOOK_CLIENT_ID not set" };
+  const msgId = params.message_id?.trim();
+  if (!msgId) return { error: "message_id is required" };
+  const toList = Array.isArray(params.to) ? params.to : [params.to];
+  if (!toList.length) return { error: "to is required" };
+
+  const token = await getToken(clientId, clientSecret, refreshToken);
+  const payload: Record<string, unknown> = {
+    toRecipients: toList.map(e => ({ emailAddress: { address: e.trim() } })),
+  };
+  if (params.comment) payload.comment = params.comment;
+
+  const res = await graphPost(token, `/me/messages/${encodeURIComponent(msgId)}/forward`, payload) as Record<string, unknown>;
+  if (res.error) return { error: JSON.stringify(res.error) };
+  return { ok: true, message: `✓ Forwarded to ${toList.join(", ")}` };
+}
+
+export async function moveMessage(
+  config: OutlookMailConfig,
+  params: { message_id: string; destination_folder: string },
+): Promise<unknown> {
+  const { clientId, clientSecret, refreshToken } = config;
+  if (!clientId) return { error: "OUTLOOK_CLIENT_ID not set" };
+  const msgId = params.message_id?.trim();
+  if (!msgId) return { error: "message_id is required" };
+  if (!params.destination_folder?.trim()) return { error: "destination_folder is required" };
+
+  const token = await getToken(clientId, clientSecret, refreshToken);
+  const res = await graphPost(token, `/me/messages/${encodeURIComponent(msgId)}/move`, { destinationId: params.destination_folder }) as Record<string, unknown>;
+  if (res.error) return { error: JSON.stringify(res.error) };
+  return { ok: true, new_id: res.id ?? null };
+}
+
+export async function flagMessage(
+  config: OutlookMailConfig,
+  params: { message_id: string; flag_status: "flagged" | "complete" | "notFlagged" },
+): Promise<unknown> {
+  const { clientId, clientSecret, refreshToken } = config;
+  if (!clientId) return { error: "OUTLOOK_CLIENT_ID not set" };
+  const msgId = params.message_id?.trim();
+  if (!msgId) return { error: "message_id is required" };
+
+  const token = await getToken(clientId, clientSecret, refreshToken);
+  const res = await graphPatch(token, `/me/messages/${encodeURIComponent(msgId)}`, { flag: { flagStatus: params.flag_status } }) as Record<string, unknown>;
+  if (res.error) return { error: JSON.stringify(res.error) };
+  return { ok: true, flag_status: params.flag_status };
 }

--- a/plugins/outlook-mail/src/index.ts
+++ b/plugins/outlook-mail/src/index.ts
@@ -204,5 +204,58 @@ export const createEntry = definePlugin({
         }
       },
     }),
+
+    tool({
+      name: "outlook_move",
+      label: "Outlook Move Message",
+      description: "Move an Outlook message to a different mail folder.",
+      parameters: Type.Object({
+        message_id: Type.String({ description: "The Microsoft Graph message ID to move." }),
+        destination_folder: Type.String({ description: "Target folder name or well-known folder name (inbox, archive, deleteditems, junkemail, sentitems, drafts)." }),
+      }),
+      async execute({ message_id, destination_folder }, config) {
+        try {
+          const resolvedConfig: OutlookMailConfig = {
+            clientId: String(config.clientId ?? process.env.OUTLOOK_CLIENT_ID ?? ""),
+            clientSecret: String(config.clientSecret ?? process.env.OUTLOOK_CLIENT_SECRET ?? ""),
+            refreshToken: String(config.refreshToken ?? process.env.OUTLOOK_REFRESH_TOKEN ?? ""),
+          };
+          return await moveMessage(resolvedConfig, {
+            message_id: String(message_id ?? ""),
+            destination_folder: String(destination_folder ?? ""),
+          });
+        } catch (e) {
+          return { error: (e as Error).message };
+        }
+      },
+    }),
+
+    tool({
+      name: "outlook_flag",
+      label: "Outlook Flag Message",
+      description: "Flag, complete, or unflag an Outlook message.",
+      parameters: Type.Object({
+        message_id: Type.String({ description: "The Microsoft Graph message ID to flag." }),
+        flag_status: Type.Union(
+          [Type.Literal("flagged"), Type.Literal("complete"), Type.Literal("notFlagged")],
+          { description: "Flag status: 'flagged', 'complete', or 'notFlagged'." },
+        ),
+      }),
+      async execute({ message_id, flag_status }, config) {
+        try {
+          const resolvedConfig: OutlookMailConfig = {
+            clientId: String(config.clientId ?? process.env.OUTLOOK_CLIENT_ID ?? ""),
+            clientSecret: String(config.clientSecret ?? process.env.OUTLOOK_CLIENT_SECRET ?? ""),
+            refreshToken: String(config.refreshToken ?? process.env.OUTLOOK_REFRESH_TOKEN ?? ""),
+          };
+          return await flagMessage(resolvedConfig, {
+            message_id: String(message_id ?? ""),
+            flag_status: flag_status as "flagged" | "complete" | "notFlagged",
+          });
+        } catch (e) {
+          return { error: (e as Error).message };
+        }
+      },
+    }),
   ],
 });

--- a/plugins/outlook-mail/src/index.ts
+++ b/plugins/outlook-mail/src/index.ts
@@ -6,12 +6,12 @@
 
 import { definePlugin } from "carapace-plugin-sdk";
 import { Type } from "@sinclair/typebox";
-import { getInbox, searchMail, readMessage, saveAttachments, type OutlookMailConfig } from "./handlers.js";
+import { getInbox, searchMail, readMessage, saveAttachments, sendMessage, replyToMessage, forwardMessage, moveMessage, flagMessage, type OutlookMailConfig } from "./handlers.js";
 
 export const createEntry = definePlugin({
   id: "outlook-mail",
   name: "Outlook Mail",
-  description: "Search and read messages from Outlook inboxes",
+  description: "Search, read, send, reply to, and forward messages in Outlook",
 
   configSchema: Type.Object({
     clientId: Type.Optional(Type.String({ description: "Microsoft OAuth client ID" })),
@@ -124,6 +124,81 @@ export const createEntry = definePlugin({
             output_dir: String(output_dir ?? ""),
             content_types,
           });
+        } catch (e) {
+          return { error: (e as Error).message };
+        }
+      },
+    }),
+
+    tool({
+      name: "outlook_send",
+      label: "Outlook Send Email",
+      description: "Send a plain-text email via Outlook, with optional file attachments.",
+      parameters: Type.Object({
+        to: Type.Union([Type.String(), Type.Array(Type.String())], { description: "Recipient email address(es)." }),
+        cc: Type.Optional(Type.Array(Type.String(), { description: "CC recipient email address(es)." })),
+        subject: Type.String({ description: "Email subject line." }),
+        body: Type.String({ description: "Plain-text email body." }),
+        signature: Type.Optional(Type.String({ description: "Signature block appended after body." })),
+        attachment: Type.Optional(Type.Array(Type.String(), { description: "File path(s) to attach." })),
+        in_reply_to: Type.Optional(Type.String({ description: "Message-ID of the email being replied to (enables threading). Include angle brackets, e.g. <abc@mail.example.com>." })),
+        references: Type.Optional(Type.String({ description: "Space-separated list of Message-IDs for the full thread References header." })),
+      }),
+      async execute({ to, cc, subject, body, signature, attachment, in_reply_to, references }, config) {
+        try {
+          const resolvedConfig: OutlookMailConfig = {
+            clientId: String(config.clientId ?? process.env.OUTLOOK_CLIENT_ID ?? ""),
+            clientSecret: String(config.clientSecret ?? process.env.OUTLOOK_CLIENT_SECRET ?? ""),
+            refreshToken: String(config.refreshToken ?? process.env.OUTLOOK_REFRESH_TOKEN ?? ""),
+          };
+          return await sendMessage(resolvedConfig, { to, cc, subject, body, signature, attachment, in_reply_to, references });
+        } catch (e) {
+          return { error: (e as Error).message };
+        }
+      },
+    }),
+
+    tool({
+      name: "outlook_reply",
+      label: "Outlook Reply to Message",
+      description: "Reply to an existing Outlook message with proper threading. Handles In-Reply-To and References headers automatically via Microsoft Graph.",
+      parameters: Type.Object({
+        message_id: Type.String({ description: "The Microsoft Graph message ID to reply to." }),
+        body: Type.String({ description: "Reply body text." }),
+        reply_all: Type.Optional(Type.Boolean({ description: "Reply to all recipients (default: false)." })),
+        signature: Type.Optional(Type.String({ description: "Signature block appended after body." })),
+      }),
+      async execute({ message_id, body, reply_all, signature }, config) {
+        try {
+          const resolvedConfig: OutlookMailConfig = {
+            clientId: String(config.clientId ?? process.env.OUTLOOK_CLIENT_ID ?? ""),
+            clientSecret: String(config.clientSecret ?? process.env.OUTLOOK_CLIENT_SECRET ?? ""),
+            refreshToken: String(config.refreshToken ?? process.env.OUTLOOK_REFRESH_TOKEN ?? ""),
+          };
+          return await replyToMessage(resolvedConfig, { message_id: String(message_id ?? ""), body: String(body ?? ""), reply_all, signature });
+        } catch (e) {
+          return { error: (e as Error).message };
+        }
+      },
+    }),
+
+    tool({
+      name: "outlook_forward",
+      label: "Outlook Forward Message",
+      description: "Forward an existing Outlook message to new recipients.",
+      parameters: Type.Object({
+        message_id: Type.String({ description: "The Microsoft Graph message ID to forward." }),
+        to: Type.Union([Type.String(), Type.Array(Type.String())], { description: "Recipient email address(es) to forward to." }),
+        comment: Type.Optional(Type.String({ description: "Optional note to prepend to the forwarded message." })),
+      }),
+      async execute({ message_id, to, comment }, config) {
+        try {
+          const resolvedConfig: OutlookMailConfig = {
+            clientId: String(config.clientId ?? process.env.OUTLOOK_CLIENT_ID ?? ""),
+            clientSecret: String(config.clientSecret ?? process.env.OUTLOOK_CLIENT_SECRET ?? ""),
+            refreshToken: String(config.refreshToken ?? process.env.OUTLOOK_REFRESH_TOKEN ?? ""),
+          };
+          return await forwardMessage(resolvedConfig, { message_id: String(message_id ?? ""), to, comment });
         } catch (e) {
           return { error: (e as Error).message };
         }


### PR DESCRIPTION
## Summary

Adds write/action capabilities to the `outlook-mail` plugin:

**New tools:**
- `outlook_send` — send a new email (to, cc, subject, body, attachments, threading headers)
- `outlook_reply` — reply or reply-all to an existing message; threading handled by Graph API
- `outlook_forward` — forward a message to new recipients with optional comment
- `outlook_move` — move a message to another folder (archive, trash, etc.)
- `outlook_flag` — flag, complete, or unflag a message

**Implementation notes:**
- Send/reply/forward require `Mail.Send` scope — if the current refresh token lacks this scope, the tool will return a token error and Jeff will need to re-authorize
- `outlook_send` uses create-draft + send pattern (POST /me/messages then POST /me/messages/{id}/send) for reliability
- Reply/forward use the Graph built-in endpoints so threading is correct automatically
- Scope requested at token time: `Mail.Read Mail.Send Mail.ReadWrite`

Closes JeffSteinbok/octo#228